### PR TITLE
feat: add getFillTypeString() for PathKit

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -111,6 +111,7 @@ export class Path2D {
   op(path: Path2D, operation: PathOp): Path2D
   toSVGString(): string
   getFillType(): FillType
+  getFillTypeString(): string
   setFillType(type: FillType): void
   simplify(): Path2D
   asWinding(): Path2D

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ export class Path2D {
   op(path: Path2D, operation: PathOp): Path2D
   toSVGString(): string
   getFillType(): FillType
+  getFillTypeString(): string
   setFillType(type: FillType): void
   simplify(): Path2D
   asWinding(): Path2D

--- a/__test__/pathkit.spec.ts
+++ b/__test__/pathkit.spec.ts
@@ -64,6 +64,19 @@ test('FillType must be Winding after conversion by AsWinding()', (t) => {
   t.is(path.asWinding().getFillType(), FillType.Winding)
 })
 
+test('getFillTypeString()', (t) => {
+  const path = new Path2D()
+  path.rect(1, 2, 3, 4)
+  t.is(path.getFillTypeString(), 'nonzero')
+})
+
+test('getFillTypeString() and setFillType()', (t) => {
+  const path = new Path2D()
+  path.rect(1, 2, 3, 4)
+  path.setFillType(FillType.EvenOdd)
+  t.is(path.getFillTypeString(), 'evenodd')
+})
+
 test('Path FillType must be converted from nonzero to evenodd', (t) => {
   const pathCircle = new Path2D(
     'M50 87.5776C70.7536 87.5776 87.5776 70.7536 87.5776 50C87.5776 29.2464 70.7536 12.4224 50 12.4224C29.2464 12.4224 12.4224 29.2464 12.4224 50C12.4224 70.7536 29.2464 87.5776 50 87.5776ZM50 100C77.6142 100 100 77.6142 100 50C100 22.3858 77.6142 0 50 0C22.3858 0 0 22.3858 0 50C0 77.6142 22.3858 100 50 100Z',

--- a/index.d.ts
+++ b/index.d.ts
@@ -218,6 +218,7 @@ export class Path2D {
   op(path: Path2D, operation: PathOp): Path2D
   toSVGString(): string
   getFillType(): FillType
+  getFillTypeString(): string
   setFillType(type: FillType): void
   simplify(): Path2D
   asWinding(): Path2D

--- a/index.js
+++ b/index.js
@@ -58,6 +58,18 @@ Path2D.prototype.stroke = function stroke(strokeOptions = {}) {
   return this._stroke(width, miterLimit, join, cap)
 }
 
+Path2D.prototype.getFillTypeString = function getFillTypeString() {
+  const fillType = this.getFillType()
+
+  if (fillType === FillType.Winding) {
+    return 'nonzero'
+  } else if (fillType === FillType.EvenOdd) {
+    return 'evenodd'
+  } else {
+    return 'nonzero' // default
+  }
+}
+
 function createCanvas(width, height) {
   const canvasElement = new CanvasElement(width, height)
   const ctx = new CanvasRenderingContext2D(width, height)


### PR DESCRIPTION
Returns a String representing the fillType of this path. The values are either `nonzero` or `evenodd`.

See also: https://skia.org/docs/user/modules/pathkit/#getfilltypestring