### PR TITLE
feat: add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,26 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors or IDEs
+# http://editorconfig.org
+root = true
+
+# All files
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+# Tab indentation (no size specified)
+[Makefile]
+indent_style = tab
+
+[*.{c,h,cpp,hpp}]
+indent_size = 2
+
+[*.rs]
+indent_size = 2


### PR DESCRIPTION
`.editorconfig` is only responsible for basic indentation and line wrapping, and does not format specific styles. For example, the specific formatting of JS uses prettier, and the formatting of C++ files uses [clang-format](https://clang.llvm.org/docs/ClangFormat.html).