### PR TITLE
Reduce install size for linux glibc/musl

### DIFF
--- a/npm/linux-arm64-gnu/install.js
+++ b/npm/linux-arm64-gnu/install.js
@@ -1,0 +1,13 @@
+// Node.js 10.x, ignore
+if (!process.report || typeof process.report.getReport !== 'function') {
+  process.exit(0)
+}
+
+// Only GNU system has this field
+const { glibcVersionRuntime } = process.report.getReport().header
+
+if (glibcVersionRuntime) {
+  process.exit(0)
+} else {
+  process.exit(1)
+}

--- a/npm/linux-arm64-gnu/package.json
+++ b/npm/linux-arm64-gnu/package.json
@@ -9,8 +9,12 @@
   ],
   "main": "skia.linux-arm64-gnu.node",
   "files": [
-    "skia.linux-arm64-gnu.node"
+    "skia.linux-arm64-gnu.node",
+    "install.js"
   ],
+  "scripts": {
+    "install": "node install.js"
+  },
   "description": "Canvas for Node.js with skia backend",
   "keywords": [
     "napi-rs",

--- a/npm/linux-arm64-musl/install.js
+++ b/npm/linux-arm64-musl/install.js
@@ -1,0 +1,13 @@
+// Node.js 10.x, ignore
+if (!process.report || typeof process.report.getReport !== 'function') {
+  process.exit(0)
+}
+
+// Only GNU system has this field
+const { glibcVersionRuntime } = process.report.getReport().header
+
+if (glibcVersionRuntime) {
+  process.exit(1)
+} else {
+  process.exit(0)
+}

--- a/npm/linux-arm64-musl/package.json
+++ b/npm/linux-arm64-musl/package.json
@@ -9,8 +9,12 @@
   ],
   "main": "skia.linux-arm64-musl.node",
   "files": [
-    "skia.linux-arm64-musl.node"
+    "skia.linux-arm64-musl.node",
+    "install.js"
   ],
+  "scripts": {
+    "install": "node install.js"
+  },
   "description": "Canvas for Node.js with skia backend",
   "keywords": [
     "napi-rs",

--- a/npm/linux-x64-gnu/install.js
+++ b/npm/linux-x64-gnu/install.js
@@ -1,0 +1,13 @@
+// Node.js 10.x, ignore
+if (!process.report || typeof process.report.getReport !== 'function') {
+  process.exit(0)
+}
+
+// Only GNU system has this field
+const { glibcVersionRuntime } = process.report.getReport().header
+
+if (glibcVersionRuntime) {
+  process.exit(0)
+} else {
+  process.exit(1)
+}

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -9,8 +9,12 @@
   ],
   "main": "skia.linux-x64-gnu.node",
   "files": [
-    "skia.linux-x64-gnu.node"
+    "skia.linux-x64-gnu.node",
+    "install.js"
   ],
+  "scripts": {
+    "install": "node install.js"
+  },
   "description": "Canvas for Node.js with skia backend",
   "keywords": [
     "napi-rs",

--- a/npm/linux-x64-musl/install.js
+++ b/npm/linux-x64-musl/install.js
@@ -1,0 +1,13 @@
+// Node.js 10.x, ignore
+if (!process.report || typeof process.report.getReport !== 'function') {
+  process.exit(0)
+}
+
+// Only GNU system has this field
+const { glibcVersionRuntime } = process.report.getReport().header
+
+if (glibcVersionRuntime) {
+  process.exit(1)
+} else {
+  process.exit(0)
+}

--- a/npm/linux-x64-musl/package.json
+++ b/npm/linux-x64-musl/package.json
@@ -9,8 +9,12 @@
   ],
   "main": "skia.linux-x64-musl.node",
   "files": [
-    "skia.linux-x64-musl.node"
+    "skia.linux-x64-musl.node",
+    "install.js"
   ],
+  "scripts": {
+    "install": "node install.js"
+  },
   "description": "Canvas for Node.js with skia backend",
   "keywords": [
     "napi-rs",


### PR DESCRIPTION
Currently, linux installs both glibc and musl binaries.

This PR adds the `install` script to prevent installing unused binaries, reducing the install size.

We originally thought this could be added to Node.js core and thus npm but [it was rejected](https://github.com/nodejs/node/pull/41338).