### PR TITLE
Fix the line to result of path empty case (issue: #409) + add the example

### DIFF
--- a/example/path-empty-line-to.js
+++ b/example/path-empty-line-to.js
@@ -1,0 +1,24 @@
+const fs = require('fs').promises
+const { join } = require('path')
+
+const { createCanvas, Image } = require('../index')
+/* eslint-disable no-console */
+
+async function main() {
+  const w = 1052
+  const h = 744
+
+  // create a canvas
+  const canvas = createCanvas(w, h)
+  const ctx = canvas.getContext('2d')
+
+  ctx.beginPath()
+  ctx.lineTo(100, 100)
+  ctx.lineTo(300, 150)
+  ctx.stroke()
+
+  const data = await canvas.encode('png')
+  await fs.writeFile(join(__dirname, 'path-empty-line-to.png'), data)
+}
+
+main()

--- a/src/sk.rs
+++ b/src/sk.rs
@@ -2453,6 +2453,12 @@ impl Path {
     self.transform_self(&rotated);
   }
 
+  pub fn scoot(&mut self, x: f32, y: f32) {
+    if self.is_empty() {
+      self.move_to(x, y);
+    }
+  }
+
   pub fn arc(
     &mut self,
     center_x: f32,
@@ -2509,6 +2515,7 @@ impl Path {
   }
 
   pub fn line_to(&mut self, x: f32, y: f32) {
+    self.scoot(x, y);
     unsafe {
       ffi::skiac_path_line_to(self.0, x, y);
     }


### PR DESCRIPTION
Fix the issue https://github.com/Brooooooklyn/canvas/issues/409

and + example

这里预期用和 skia-canvas 库用同一种方式解决吧

我也补上了用例 example/path-empty-line-to.js

验证是没问题的

![line-to](https://user-images.githubusercontent.com/11075892/151028539-1624efad-c93a-4315-bef2-c33ddbae85d3.png)

