### PR TITLE
fix: Fix the issue of arc to + bezier to + quad to at empty path case

### DIFF
--- a/src/sk.rs
+++ b/src/sk.rs
@@ -2505,6 +2505,7 @@ impl Path {
   }
 
   pub fn arc_to_tangent(&mut self, x1: f32, y1: f32, x2: f32, y2: f32, radius: f32) {
+    self.scoot(x1, y1);
     unsafe { ffi::skiac_path_arc_to_tangent(self.0, x1, y1, x2, y2, radius) }
   }
 
@@ -2522,12 +2523,14 @@ impl Path {
   }
 
   pub fn cubic_to(&mut self, x1: f32, y1: f32, x2: f32, y2: f32, x3: f32, y3: f32) {
+    self.scoot(x1, y1);
     unsafe {
       ffi::skiac_path_cubic_to(self.0, x1, y1, x2, y2, x3, y3);
     }
   }
 
   pub fn quad_to(&mut self, cpx: f32, cpy: f32, x: f32, y: f32) {
+    self.scoot(cpx, cpy);
     unsafe {
       ffi::skiac_path_quad_to(self.0, cpx, cpy, x, y);
     }


### PR DESCRIPTION
Fixed the issue of empty path also happened at arc to + bezier to + quad to, and has test passed.

另外三个方法的空 Path 场景也修复完成了 也自测没问题了

```js
// arc to
ctx.beginPath()
ctx.arcTo(180, 90, 200, 30, 30)
ctx.arcTo(180, 130, 110, 130, 130)
ctx.stroke()
```

![path-empty-arc-to](https://user-images.githubusercontent.com/11075892/151759661-2219be0c-1f9f-43fa-95ee-f20e50486b1d.png)

```js
// bézier curve to
ctx.beginPath()
ctx.bezierCurveTo(40, 20, 10, 10, 30, 30)
ctx.bezierCurveTo(120, 160, 180, 10, 220, 140)
ctx.stroke()
```

![path-empty-bezier-curve-to](https://user-images.githubusercontent.com/11075892/151759679-88d2509a-8af6-41d3-9b42-1a0f3cf3ec7c.png)

```js
// quadratic curve to
ctx.beginPath()
ctx.quadraticCurveTo(10, 10, 20, 110)
ctx.quadraticCurveTo(230, 150, 250, 20)
ctx.stroke()
```

![path-empty-quadratic-curve-to](https://user-images.githubusercontent.com/11075892/151759690-783198bb-84cf-4c39-a9b3-1c678861e0af.png)

