### PR TITLE
Try to fix the encode method default quality issue

### DIFF
--- a/example/anime-girl-quality.js
+++ b/example/anime-girl-quality.js
@@ -1,0 +1,42 @@
+const fs = require('fs').promises
+const { join } = require('path')
+const { performance } = require('perf_hooks')
+
+const { createCanvas, Image } = require('../index')
+/* eslint-disable no-console */
+
+async function main() {
+  const file = await fs.readFile(join(__dirname, './anime-girl.svg'))
+
+  const image = new Image()
+  image.src = file
+
+  const w = 1052
+  const h = 744
+
+  // resize SVG
+  image.width = w
+  image.height = h
+
+  // create a canvas of the same size as the image
+  const canvas = createCanvas(w, h)
+  const ctx = canvas.getContext('2d')
+
+  // fill the canvas with the image
+  ctx.drawImage(image, 0, 0)
+
+  const webpData = await canvas.encode('webp')
+  await fs.writeFile(join(__dirname, 'anime-girl-default.webp'), webpData)
+
+  const webpData80 = await canvas.encode('webp', 80)
+  await fs.writeFile(join(__dirname, 'anime-girl-80.webp'), webpData80)
+
+  const webpData92 = await canvas.encode('webp', 92)
+  await fs.writeFile(join(__dirname, 'anime-girl-92.webp'), webpData92)
+
+  console.log('✨ webp default quality size', webpData.length)
+  console.log('✨ webp quality 80 size', webpData80.length)
+  console.log('✨ webp quality 92 size', webpData92.length)
+}
+
+main()

--- a/index.js
+++ b/index.js
@@ -237,7 +237,7 @@ function createCanvas(width, height, flag) {
         }),
       )
     }
-    return canvasEncode.call(this, type, qualityOrConfig || 92)
+    return canvasEncode.call(this, type, qualityOrConfig)
   }
 
   canvasElement.encodeSync = function encodeSync(type, qualityOrConfig) {
@@ -251,7 +251,7 @@ function createCanvas(width, height, flag) {
         }),
       )
     }
-    return canvasEncodeSync.call(this, type, qualityOrConfig || 92)
+    return canvasEncodeSync.call(this, type, qualityOrConfig)
   }
 
   canvasElement.toBuffer = function toBuffer(type = 'image/png', qualityOrConfig) {
@@ -265,7 +265,7 @@ function createCanvas(width, height, flag) {
         }),
       )
     }
-    return canvasToBuffer.call(this, type, qualityOrConfig || 92)
+    return canvasToBuffer.call(this, type, qualityOrConfig)
   }
 
   canvasElement.toDataURL = function toDataURL(type = 'image/png', qualityOrConfig) {
@@ -279,7 +279,7 @@ function createCanvas(width, height, flag) {
         }),
       )
     }
-    return canvasToDataURL.call(this, type, qualityOrConfig || 92)
+    return canvasToDataURL.call(this, type, qualityOrConfig)
   }
 
   canvasElement.toDataURLAsync = function toDataURLAsync(type = 'image/png', qualityOrConfig) {
@@ -293,7 +293,7 @@ function createCanvas(width, height, flag) {
         }),
       )
     }
-    return canvasToDataURLAsync.call(this, type, qualityOrConfig || 92)
+    return canvasToDataURLAsync.call(this, type, qualityOrConfig)
   }
 
   return canvasElement

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,12 +168,12 @@ fn create_context(ctx: CallContext) -> Result<JsUndefined> {
 fn encode(ctx: CallContext) -> Result<JsObject> {
   let format = ctx.get::<JsString>(0)?.into_utf8()?;
   let format_str = format.as_str()?;
-  let quality = if format_str != "avif" {
-    ctx.get::<JsNumber>(1)?.get_uint32()? as u8
-  } else if format_str == "webp" {
-    DEFAULT_WEBP_QUALITY
-  } else {
-    DEFAULT_JPEG_QUALITY
+  let quality = match ctx.get::<JsNumber>(1)?.get_uint32() {
+    Ok(number) => number as u8,
+    Err(_e) => match format_str {
+      "webp" => DEFAULT_WEBP_QUALITY,
+      _ => DEFAULT_JPEG_QUALITY,
+    },
   };
   let this = ctx.this_unchecked::<JsObject>();
   let ctx_js = this.get_named_property::<JsObject>("ctx")?;
@@ -203,12 +203,12 @@ fn encode(ctx: CallContext) -> Result<JsObject> {
 fn encode_sync(ctx: CallContext) -> Result<JsBuffer> {
   let format = ctx.get::<JsString>(0)?.into_utf8()?;
   let format_str = format.as_str()?;
-  let quality = if format_str != "avif" {
-    ctx.get::<JsNumber>(1)?.get_uint32()? as u8
-  } else if format_str == "webp" {
-    DEFAULT_WEBP_QUALITY
-  } else {
-    DEFAULT_JPEG_QUALITY
+  let quality = match ctx.get::<JsNumber>(1)?.get_uint32() {
+    Ok(number) => number as u8,
+    Err(_e) => match format_str {
+      "webp" => DEFAULT_WEBP_QUALITY,
+      _ => DEFAULT_JPEG_QUALITY,
+    },
   };
   let this = ctx.this_unchecked::<JsObject>();
   let ctx_js = this.get_named_property::<JsObject>("ctx")?;
@@ -281,13 +281,12 @@ fn encode_sync(ctx: CallContext) -> Result<JsBuffer> {
 fn to_buffer(ctx: CallContext) -> Result<JsBuffer> {
   let mime_js = ctx.get::<JsString>(0)?.into_utf8()?;
   let mime = mime_js.as_str()?;
-  let quality = if mime != MIME_AVIF {
-    ctx.get::<JsNumber>(1)?.get_uint32()? as u8
-  } else if mime == MIME_WEBP {
-    DEFAULT_WEBP_QUALITY
-  } else {
-    // https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toDataURL
-    DEFAULT_JPEG_QUALITY
+  let quality = match ctx.get::<JsNumber>(1)?.get_uint32() {
+    Ok(number) => number as u8,
+    Err(_e) => match mime {
+      MIME_WEBP => DEFAULT_WEBP_QUALITY,
+      _ => DEFAULT_JPEG_QUALITY, // https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toDataURL
+    },
   };
 
   let context_data = get_data_ref(&ctx, mime, quality)?;
@@ -336,13 +335,12 @@ fn data(ctx: CallContext) -> Result<JsBuffer> {
 fn to_data_url(ctx: CallContext) -> Result<JsString> {
   let mime_js = ctx.get::<JsString>(0)?.into_utf8()?;
   let mime = mime_js.as_str()?;
-  let quality = if mime != MIME_AVIF {
-    ctx.get::<JsNumber>(1)?.get_uint32()? as u8
-  } else if mime == MIME_WEBP {
-    DEFAULT_WEBP_QUALITY
-  } else {
-    // https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toDataURL
-    DEFAULT_JPEG_QUALITY
+  let quality = match ctx.get::<JsNumber>(1)?.get_uint32() {
+    Ok(number) => number as u8,
+    Err(_e) => match mime {
+      MIME_WEBP => DEFAULT_WEBP_QUALITY,
+      _ => DEFAULT_JPEG_QUALITY, // https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toDataURL
+    },
   };
   let data_ref = get_data_ref(&ctx, mime, quality)?;
   let mut output = format!("data:{};base64,", &mime);
@@ -361,13 +359,12 @@ fn to_data_url(ctx: CallContext) -> Result<JsString> {
 fn to_data_url_async(ctx: CallContext) -> Result<JsObject> {
   let mime_js = ctx.get::<JsString>(0)?.into_utf8()?;
   let mime = mime_js.as_str()?;
-  let quality = if mime != MIME_AVIF {
-    ctx.get::<JsNumber>(1)?.get_uint32()? as u8
-  } else if mime == MIME_WEBP {
-    DEFAULT_WEBP_QUALITY
-  } else {
-    // https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toDataURL
-    DEFAULT_JPEG_QUALITY
+  let quality = match ctx.get::<JsNumber>(1)?.get_uint32() {
+    Ok(number) => number as u8,
+    Err(_e) => match mime {
+      MIME_WEBP => DEFAULT_WEBP_QUALITY,
+      _ => DEFAULT_JPEG_QUALITY, // https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toDataURL
+    },
   };
   let data_ref = get_data_ref(&ctx, mime, quality)?;
   let async_task = AsyncDataUrl {


### PR DESCRIPTION
尝试修复了一下 `.encode(type, quality)` 方法的 quality 默认值的问题 [https://github.com/Brooooooklyn/canvas/issues/407](https://github.com/Brooooooklyn/canvas/issues/407)

以及关联的几个方法 确认测试通过

可看下是否是预期之内的方式