### PR TITLE
chore: note to improve, libc version detection only supports Node.js >= v13.12.0 or v12.17.0

### DIFF
--- a/npm/linux-arm64-gnu/install.js
+++ b/npm/linux-arm64-gnu/install.js
@@ -1,4 +1,5 @@
-// Node.js 10.x, ignore
+// Node.js < v13.12.0, v12.17.0, ignore
+// https://nodejs.org/api/process.html#processreport
 if (!process.report || typeof process.report.getReport !== 'function') {
   process.exit(0)
 }

--- a/npm/linux-arm64-musl/install.js
+++ b/npm/linux-arm64-musl/install.js
@@ -1,4 +1,5 @@
-// Node.js 10.x, ignore
+// Node.js < v13.12.0, v12.17.0, ignore
+// https://nodejs.org/api/process.html#processreport
 if (!process.report || typeof process.report.getReport !== 'function') {
   process.exit(0)
 }

--- a/npm/linux-x64-gnu/install.js
+++ b/npm/linux-x64-gnu/install.js
@@ -1,4 +1,5 @@
-// Node.js 10.x, ignore
+// Node.js < v13.12.0, v12.17.0, ignore
+// https://nodejs.org/api/process.html#processreport
 if (!process.report || typeof process.report.getReport !== 'function') {
   process.exit(0)
 }

--- a/npm/linux-x64-musl/install.js
+++ b/npm/linux-x64-musl/install.js
@@ -1,4 +1,5 @@
-// Node.js 10.x, ignore
+// Node.js < v13.12.0, v12.17.0, ignore
+// https://nodejs.org/api/process.html#processreport
 if (!process.report || typeof process.report.getReport !== 'function') {
   process.exit(0)
 }


### PR DESCRIPTION
https://nodejs.org/api/process.html#processreport

Version | Changes
-- | --
v13.12.0, v12.17.0 | This API is no longer experimental.
v11.8.0 | Added in: v11.8.0

cc @styfle 