### PR TITLE
feat(loadImage): add stream and alt support

### DIFF
--- a/__test__/loadimage.spec.ts
+++ b/__test__/loadimage.spec.ts
@@ -1,5 +1,6 @@
 import { join } from 'path'
 import test from 'ava'
+import fs from 'fs'
 
 import { createCanvas, Image, loadImage } from '../index'
 
@@ -8,6 +9,18 @@ import { snapshotImage } from './image-snapshot'
 test('should load file src', async (t) => {
   const img = await loadImage(join(__dirname, '../example/simple.png'))
   t.is(img instanceof Image, true)
+})
+
+test('should load file stream', async (t) => {
+  const img = await loadImage(fs.createReadStream(join(__dirname, '../example/simple.png')))
+  t.is(img instanceof Image, true)
+})
+
+test('should load image with alt', async (t) => {
+  const img = await loadImage(join(__dirname, '../example/simple.png'), {
+    alt: 'demo-image',
+  })
+  t.is(img.alt, 'demo-image')
 })
 
 test('should load remote url', async (t) => {

--- a/index.d.ts
+++ b/index.d.ts
@@ -390,11 +390,12 @@ export const enum SvgExportFlag {
 export function convertSVGTextToPath(svg: Buffer | string): Buffer
 
 export interface LoadImageOptions {
-  maxRedirects?: number
-  requestOptions?: import('http').RequestOptions
+  alt?: string,
+  maxRedirects?: number,
+  requestOptions?: import('http').RequestOptions,
 }
 
 export function loadImage(
-  source: string | URL | Buffer | ArrayBufferLike | Uint8Array | Image,
+  source: string | URL | Buffer | ArrayBufferLike | Uint8Array | Image | import('stream').Readable,
   options?: LoadImageOptions,
 ): Promise<Image>

--- a/load-image.js
+++ b/load-image.js
@@ -1,10 +1,11 @@
 const fs = require('fs')
 const { Image } = require('./js-binding')
+const { Readable } = require('stream')
 
 let http, https
 
 const MAX_REDIRECTS = 20,
-  REDIRECT_STATUSES = [301, 302],
+  REDIRECT_STATUSES = new Set([301, 302]),
   DATA_URI = /^\s*data:/
 
 /**
@@ -13,24 +14,26 @@ const MAX_REDIRECTS = 20,
  * @param {object} options Options passed to the loader
  */
 module.exports = async function loadImage(source, options = {}) {
+  // load readable stream as image
+  if (source instanceof Readable) return createImage(await consumeStream(source), options.alt)
   // use the same buffer without copying if the source is a buffer
-  if (Buffer.isBuffer(source)) return createImage(source)
+  if (Buffer.isBuffer(source)) return createImage(source, options.alt)
   // construct a buffer if the source is buffer-like
-  if (isBufferLike(source)) return createImage(Buffer.from(source))
+  if (isBufferLike(source)) return createImage(Buffer.from(source), options.alt)
   // if the source is Image instance, copy the image src to new image
-  if (source instanceof Image) return createImage(source.src)
+  if (source instanceof Image) return createImage(source.src, options.alt)
   // if source is string and in data uri format, construct image using data uri
   if (typeof source === 'string' && DATA_URI.test(source)) {
     const commaIdx = source.indexOf(',')
     const encoding = source.lastIndexOf('base64', commaIdx) < 0 ? 'utf-8' : 'base64'
     const data = Buffer.from(source.slice(commaIdx + 1), encoding)
-    return createImage(data)
+    return createImage(data, options.alt)
   }
   // if source is a string or URL instance
   if (typeof source === 'string' || source instanceof URL) {
     // if the source exists as a file, construct image from that file
     if (fs.existsSync(source)) {
-      return createImage(await fs.promises.readFile(source))
+      return createImage(await fs.promises.readFile(source), options.alt)
     } else {
       // the source is a remote url here
       source = !(source instanceof URL) ? new URL(source) : source
@@ -38,7 +41,7 @@ module.exports = async function loadImage(source, options = {}) {
       const data = await new Promise((resolve, reject) =>
         makeRequest(source, resolve, reject, options.maxRedirects ?? MAX_REDIRECTS, options.requestOptions),
       )
-      return createImage(data)
+      return createImage(data, options.alt)
     }
   }
 
@@ -52,10 +55,10 @@ function makeRequest(url, resolve, reject, redirectCount, requestOptions) {
   const lib = isHttps ? (!https ? (https = require('https')) : https) : !http ? (http = require('http')) : http
 
   lib.get(url, requestOptions ?? {}, (res) => {
-    const shouldRedirect = REDIRECT_STATUSES.includes(res.statusCode) && typeof res.headers.location === 'string'
+    const shouldRedirect = REDIRECT_STATUSES.has(res.statusCode) && typeof res.headers.location === 'string'
     if (shouldRedirect && redirectCount > 0)
       return makeRequest(res.headers.location, resolve, reject, redirectCount - 1, requestOptions)
-    if (typeof res.statusCode === 'number' && res.statusCode < 200 && res.statusCode >= 300) {
+    if (typeof res.statusCode === 'number' && (res.statusCode < 200 || res.statusCode >= 300)) {
       return reject(new Error(`remote source rejected with status code ${res.statusCode}`))
     }
 
@@ -74,9 +77,10 @@ function consumeStream(res) {
   })
 }
 
-function createImage(src) {
+function createImage(src, alt) {
   const image = new Image()
   image.src = src
+  if (typeof alt === 'string') image.alt = alt
   return image
 }
 


### PR DESCRIPTION
Additions to the #483

This PR adds support for `internal.Readable` streams as image source and ability to set `alt` via `loadImage`.