### PR TITLE
typings: add dom lib reference

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+/// <reference lib="dom" />
+
 export interface DOMMatrix2DInit {
   a: number
   b: number


### PR DESCRIPTION
### Why?
Without this reference, DOM types such as `CanvasRenderingContext2D` will appear as `unresolved` / `any` unless you include the DOM lib in your own tsconfig.json file.
This fixes #464 

### Before
<img src="https://cdn.discordapp.com/attachments/756784147468648478/992773179443511356/unknown.png">
<img src="https://cdn.discordapp.com/attachments/756784147468648478/992773373853708360/unknown.png">

### After
<img src="https://cdn.discordapp.com/attachments/756784147468648478/992773555085385748/unknown.png">
<img src="https://cdn.discordapp.com/attachments/756784147468648478/992773685377245194/unknown.png">