### PR TITLE
fix(loadImage): redirect handler

### DIFF
--- a/load-image.js
+++ b/load-image.js
@@ -57,7 +57,7 @@ function makeRequest(url, resolve, reject, redirectCount, requestOptions) {
   lib.get(url, requestOptions ?? {}, (res) => {
     const shouldRedirect = REDIRECT_STATUSES.has(res.statusCode) && typeof res.headers.location === 'string'
     if (shouldRedirect && redirectCount > 0)
-      return makeRequest(res.headers.location, resolve, reject, redirectCount - 1, requestOptions)
+      return makeRequest(new URL(res.headers.location), resolve, reject, redirectCount - 1, requestOptions)
     if (typeof res.statusCode === 'number' && (res.statusCode < 200 || res.statusCode >= 300)) {
       return reject(new Error(`remote source rejected with status code ${res.statusCode}`))
     }


### PR DESCRIPTION
This PR fixes a bug in the `loadImage` redirect handler. The current implementation throws an error because `res.headers.location` is passed as a string to the handler, which results in `url.protocol` being `undefined`.