### PR TITLE
fix: error listening to req

### DIFF
--- a/load-image.js
+++ b/load-image.js
@@ -60,17 +60,18 @@ function makeRequest(url, resolve, reject, redirectCount, requestOptions) {
   // lazy load the lib
   const lib = isHttps ? (!https ? (https = require('https')) : https) : !http ? (http = require('http')) : http
 
-  lib.get(url, requestOptions || {}, (res) => {
-    const shouldRedirect = REDIRECT_STATUSES.has(res.statusCode) && typeof res.headers.location === 'string'
-    if (shouldRedirect && redirectCount > 0)
-      return makeRequest(new URL(res.headers.location), resolve, reject, redirectCount - 1, requestOptions)
-    if (typeof res.statusCode === 'number' && (res.statusCode < 200 || res.statusCode >= 300)) {
-      return reject(new Error(`remote source rejected with status code ${res.statusCode}`))
-    }
+  lib
+    .get(url, requestOptions || {}, (res) => {
+      const shouldRedirect = REDIRECT_STATUSES.has(res.statusCode) && typeof res.headers.location === 'string'
+      if (shouldRedirect && redirectCount > 0)
+        return makeRequest(new URL(res.headers.location), resolve, reject, redirectCount - 1, requestOptions)
+      if (typeof res.statusCode === 'number' && (res.statusCode < 200 || res.statusCode >= 300)) {
+        return reject(new Error(`remote source rejected with status code ${res.statusCode}`))
+      }
 
-    consumeStream(res).then(resolve, reject)
-  })
-  .on("error", reject);
+      consumeStream(res).then(resolve, reject)
+    })
+    .on('error', reject)
 }
 
 // use stream/consumers in the future?

--- a/load-image.js
+++ b/load-image.js
@@ -70,6 +70,7 @@ function makeRequest(url, resolve, reject, redirectCount, requestOptions) {
 
     consumeStream(res).then(resolve, reject)
   })
+  .on("error", reject);
 }
 
 // use stream/consumers in the future?


### PR DESCRIPTION
```bash
Error: socket hang up
    at connResetException (node:internal/errors:692:14)
    at Socket.socketOnEnd (node:_http_client:478:23)
    at Socket.emit (node:events:539:35)
    at endReadableNT (node:internal/streams/readable:1345:12)
    at processTicksAndRejections (node:internal/process/task_queues:83:21)
Emitted 'error' event on ClientRequest instance at:
    at Socket.socketOnEnd (node:_http_client:478:9)
    at Socket.emit (node:events:539:35)
    at endReadableNT (node:internal/streams/readable:1345:12)
    at processTicksAndRejections (node:internal/process/task_queues:83:21) {
  code: 'ECONNRESET'
}
```