### PR TITLE
fix(types): do not use `reference` tags

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,3 @@
-/// <reference lib="dom" />
-
 // Clear all type of caches in Skia
 export function clearAllCache(): void
 


### PR DESCRIPTION
In TypeScript, `/// <reference` tags affect the whole environment, meaning that if a single dependency makes use of the tag, the user's global environment would be polluted with these types. The correct way of importing DOM types is by specifying them in the `lib` property of `tsconfig.json`, [which this library already does](https://github.com/Brooooooklyn/canvas/blob/9c505e2530a6c526b1e338a785115edeeafae267/tsconfig.json#L13).

<details>
  <summary>Without the fix, using window in a project that installed @napi-rs/canvas that doesn't use DOM types</summary>

![image](https://user-images.githubusercontent.com/53496941/191067099-7146047f-94c6-461a-b7f5-21dfe22f5d52.png)

</details>

<details>
  <summary>After the change, global scope is no longer polluted with DOM types for the project that installed this lib</summary>

![image](https://user-images.githubusercontent.com/53496941/191067326-a26a3d8f-3c6b-4c47-ba48-53bf30378a82.png)

</details>

Some examples of global pollution can be found at https://gist.github.com/RyanCavanaugh/702ebd1ca2fc060e58e634b4e30c1c1c