### PR TITLE
fix: canvas instance check

### DIFF
--- a/__test__/canvas-class.spec.ts
+++ b/__test__/canvas-class.spec.ts
@@ -1,9 +1,17 @@
 import test from 'ava'
 
-import { createCanvas, Canvas } from '../index'
+import { createCanvas, Canvas, SvgExportFlag } from '../index'
 
 test('Canvas constructor should be equal to createCanvas', (t) => {
   t.true(new Canvas(100, 100) instanceof createCanvas(100, 100).constructor)
+})
+
+test('CanvasElement instance should be equal to Canvas', (t) => {
+  t.true(createCanvas(100, 100) instanceof Canvas)
+})
+
+test('SVGCanvas instance should be equal to Canvas', (t) => {
+  t.true(createCanvas(100, 100, SvgExportFlag.NoPrettyXML) instanceof Canvas)
 })
 
 test('ctx.canvas should be equal to canvas', (t) => {

--- a/index.js
+++ b/index.js
@@ -71,6 +71,10 @@ class Canvas {
   constructor(width, height, flag) {
     return createCanvas(width, height, flag)
   }
+
+  static [Symbol.hasInstance](instance) {
+    return instance instanceof CanvasElement || instance instanceof SVGCanvas
+  }
 }
 
 if (!process.env.DISABLE_SYSTEM_FONTS_LOAD) {


### PR DESCRIPTION
fixes #630 

`constructor` check might not be possible since we have `CanvasElement` and `SVGCanvas`. Most of the times, `instanceof` should be enough.