### PR TITLE
fix: handle relative and invalid URLs in redirects when passing URL to loadImage()

### DIFF
--- a/load-image.js
+++ b/load-image.js
@@ -64,7 +64,7 @@ function makeRequest(url, resolve, reject, redirectCount, requestOptions) {
       try {
         const shouldRedirect = REDIRECT_STATUSES.has(res.statusCode) && typeof res.headers.location === 'string'
         if (shouldRedirect && redirectCount > 0)
-          return makeRequest(new URL(res.headers.location), resolve, reject, redirectCount - 1, requestOptions)
+          return makeRequest(new URL(res.headers.location, url.origin), resolve, reject, redirectCount - 1, requestOptions)
         if (typeof res.statusCode === 'number' && (res.statusCode < 200 || res.statusCode >= 300)) {
           return reject(new Error(`remote source rejected with status code ${res.statusCode}`))
         }

--- a/load-image.js
+++ b/load-image.js
@@ -61,14 +61,18 @@ function makeRequest(url, resolve, reject, redirectCount, requestOptions) {
 
   lib
     .get(url.toString(), requestOptions || {}, (res) => {
-      const shouldRedirect = REDIRECT_STATUSES.has(res.statusCode) && typeof res.headers.location === 'string'
-      if (shouldRedirect && redirectCount > 0)
-        return makeRequest(new URL(res.headers.location), resolve, reject, redirectCount - 1, requestOptions)
-      if (typeof res.statusCode === 'number' && (res.statusCode < 200 || res.statusCode >= 300)) {
-        return reject(new Error(`remote source rejected with status code ${res.statusCode}`))
+      try {
+        const shouldRedirect = REDIRECT_STATUSES.has(res.statusCode) && typeof res.headers.location === 'string'
+        if (shouldRedirect && redirectCount > 0)
+          return makeRequest(new URL(res.headers.location), resolve, reject, redirectCount - 1, requestOptions)
+        if (typeof res.statusCode === 'number' && (res.statusCode < 200 || res.statusCode >= 300)) {
+          return reject(new Error(`remote source rejected with status code ${res.statusCode}`))
+        }
+  
+        consumeStream(res).then(resolve, reject)
+      } catch (err) {
+        reject(err)
       }
-
-      consumeStream(res).then(resolve, reject)
     })
     .on('error', reject)
 }


### PR DESCRIPTION
Fixes #865, see the description of the original issue there.

This PR does two things:

- One, this wraps the `http.get()`/`https.get()` callback in `loadImage()` in a `try...catch` block so that exceptions are properly handled and passed to callers instead of crashing the Node process.
- Two, this passes `url.origin` as the second parameter to `new URL()` to ensure that "relative" redirects (where the `location` header is something like `/some/resource.jpg` instead of `https://site.com/some/resource.jpg`) do not cause the constructor to throw an exception.
  
  Redirects to another domain (for example, a `location` header to `https://other.com` from the origin `https://site.com`) are not affected by adding the second parameter. Only relative URLs are affected -- the kind that currently cause crashes in user code.

Without this fix, passing URLs to `loadImage()` **does not reliably work** when the URL has a redirect, and will instead **crash the Node process without a full stack trace**, even if the call to `loadImage()` is in a `try` block.