### PR TITLE
Indicate supported version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     }
   },
   "engines": {
-    "node": ">= 10"
+    "node": ">= 18"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",


### PR DESCRIPTION
Node 16 has been EOL for over a year ([since September 11 2023](https://nodejs.org/en/blog/announcements/nodejs16-eol)), and hasn't been tested in CI since #743 was merged last year. The `engines` field in `package.json` should reflect this as well.

This should help prevent introducing accidental behaviour changes -- for example, it looks like https://github.com/Brooooooklyn/canvas/pull/889 was merged because it was causing an error on Node 10 (EOL since 2021) and unfortunately it subtly changes the behaviour of `transformPoint` (it's no longer possible to call it with a `w` of `0`). It's possible `0` is not a valid value for `w` anyway, but in general these kind of subtle differences can cause a library to work differently for users from version to version and it would be nice to avoid unnecessary changes like this.