### PR TITLE
fix: memory leak in Image

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ base64-simd  = "0.8"
 cssparser    = "0.29"
 infer        = "0.16"
 libavif      = { version = "0.14", default-features = false, features = ["codec-aom"] }
-napi         = { version = "3.0.0-alpha.19", default-features = false, features = ["napi3", "serde-json"] }
-napi-derive  = { version = "3.0.0-alpha.17", default-features = false }
+napi         = { version = "3.0.0-alpha.20", default-features = false, features = ["napi3", "serde-json"] }
+napi-derive  = { version = "3.0.0-alpha.18", default-features = false }
 nom          = "7"
 num_cpus     = "1"
 regex        = "1"

--- a/build.rs
+++ b/build.rs
@@ -22,8 +22,12 @@ fn main() {
       env::set_var("CXX", "clang-cl");
     }
     _ => {
-      env::set_var("CC", "clang");
-      env::set_var("CXX", "clang++");
+      if env::var("CC").is_err() {
+        env::set_var("CC", "clang");
+      }
+      if env::var("CXX").is_err() {
+        env::set_var("CXX", "clang++");
+      }
     }
   }
 


### PR DESCRIPTION
There 2 leak points in the `Image` class.

1. The `Env::create_reference` was wrong in NAPI-RS, related pr: https://github.com/napi-rs/napi-rs/pull/2347, change to the `Ref::new` can resolve it.
2. The `PromiseRaw::catch` callback was leaked, it cause the whole `Image` objects not be GCed, it was fixed in https://github.com/napi-rs/napi-rs/pull/2348