### PR TITLE
fix: missing icudtl.dat on Windows

### DIFF
--- a/npm/win32-x64-msvc/package.json
+++ b/npm/win32-x64-msvc/package.json
@@ -9,7 +9,8 @@
   ],
   "main": "skia.win32-x64-msvc.node",
   "files": [
-    "skia.win32-x64-msvc.node"
+    "skia.win32-x64-msvc.node",
+    "icudtl.dat"
   ],
   "description": "Canvas for Node.js with skia backend",
   "keywords": [


### PR DESCRIPTION
- Close https://github.com/Brooooooklyn/canvas/issues/952