### PR TITLE
fix: memory leak when creating bitmap from svg

### DIFF
--- a/skia-c/skia_c.cpp
+++ b/skia-c/skia_c.cpp
@@ -1574,6 +1574,7 @@ bool skiac_bitmap_make_from_svg(const uint8_t* data,
   bitmap->allocPixels(imageinfo);
   auto sk_svg_canvas = new SkCanvas(*bitmap);
   svg_dom->render(sk_svg_canvas);
+  delete sk_svg_canvas;
   bitmap_info->bitmap = reinterpret_cast<skiac_bitmap*>(bitmap);
   bitmap_info->width = imageinfo.width();
   bitmap_info->height = imageinfo.height();


### PR DESCRIPTION
## Test code:
```js
const { loadImage } = require('./index.js');

(async () => {
    for (let i = 1; i <= 10000; i++) {
        await loadImage('./docs/imgs/boolean-operations.svg');
        console.log(i, process.memoryUsage().rss);
    }
})();
```
## Results:
Current:
```
[...]
9998 7788466176
9999 7789252608
10000 7790039040
```
With patch:
```
[...]
9998 420646912
9999 420646912
10000 420646912
```