### PR TITLE
chore: include needed dom types instead of relying on bundled DOM lib

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,279 @@ import { ReadableStream } from 'node:stream/web'
 // Clear all type of caches in Skia
 export function clearAllCache(): void
 
+interface CanvasRenderingContext2D
+  extends CanvasCompositing,
+    CanvasDrawPath,
+    CanvasFillStrokeStyles,
+    CanvasFilters,
+    CanvasImageData,
+    CanvasImageSmoothing,
+    CanvasPath,
+    CanvasPathDrawingStyles,
+    CanvasRect,
+    CanvasSettings,
+    CanvasShadowStyles,
+    CanvasState,
+    CanvasText,
+    CanvasTextDrawingStyles,
+    CanvasTransform {}
+
+interface CanvasState {
+  isContextLost(): boolean
+  reset(): void
+  restore(): void
+  save(): void
+}
+interface CanvasShadowStyles {
+  shadowBlur: number
+  shadowColor: string
+  shadowOffsetX: number
+  shadowOffsetY: number
+}
+interface CanvasRenderingContext2DSettings {
+  alpha?: boolean
+  colorSpace?: PredefinedColorSpace
+  desynchronized?: boolean
+  willReadFrequently?: boolean
+}
+interface CanvasSettings {
+  getContextAttributes(): CanvasRenderingContext2DSettings
+}
+
+interface CanvasRect {
+  clearRect(x: number, y: number, w: number, h: number): void
+  fillRect(x: number, y: number, w: number, h: number): void
+  strokeRect(x: number, y: number, w: number, h: number): void
+}
+
+interface TextMetrics {
+  readonly actualBoundingBoxAscent: number
+  readonly actualBoundingBoxDescent: number
+  readonly actualBoundingBoxLeft: number
+  readonly actualBoundingBoxRight: number
+  readonly alphabeticBaseline: number
+  readonly emHeightAscent: number
+  readonly emHeightDescent: number
+  readonly fontBoundingBoxAscent: number
+  readonly fontBoundingBoxDescent: number
+  readonly hangingBaseline: number
+  readonly ideographicBaseline: number
+  readonly width: number
+}
+
+interface CanvasText {
+  fillText(text: string, x: number, y: number, maxWidth?: number): void
+  measureText(text: string): TextMetrics
+  strokeText(text: string, x: number, y: number, maxWidth?: number): void
+}
+
+type CanvasLineCap = 'butt' | 'round' | 'square'
+type CanvasLineJoin = 'bevel' | 'miter' | 'round'
+
+interface CanvasPathDrawingStyles {
+  lineCap: CanvasLineCap
+  lineDashOffset: number
+  lineJoin: CanvasLineJoin
+  lineWidth: number
+  miterLimit: number
+  getLineDash(): number[]
+  setLineDash(segments: number[]): void
+}
+
+interface CanvasPath {
+  arc(x: number, y: number, radius: number, startAngle: number, endAngle: number, counterclockwise?: boolean): void
+  arcTo(x1: number, y1: number, x2: number, y2: number, radius: number): void
+  bezierCurveTo(cp1x: number, cp1y: number, cp2x: number, cp2y: number, x: number, y: number): void
+  closePath(): void
+  ellipse(
+    x: number,
+    y: number,
+    radiusX: number,
+    radiusY: number,
+    rotation: number,
+    startAngle: number,
+    endAngle: number,
+    counterclockwise?: boolean,
+  ): void
+  lineTo(x: number, y: number): void
+  moveTo(x: number, y: number): void
+  quadraticCurveTo(cpx: number, cpy: number, x: number, y: number): void
+  rect(x: number, y: number, w: number, h: number): void
+  roundRect(x: number, y: number, w: number, h: number, radii?: number | DOMPointInit | (number | DOMPointInit)[]): void
+}
+
+type ImageSmoothingQuality = 'high' | 'low' | 'medium'
+
+interface CanvasImageSmoothing {
+  imageSmoothingEnabled: boolean
+  imageSmoothingQuality: ImageSmoothingQuality
+}
+
+interface CanvasTransform {
+  resetTransform(): void
+  rotate(angle: number): void
+  scale(x: number, y: number): void
+  setTransform(a: number, b: number, c: number, d: number, e: number, f: number): void
+  setTransform(transform?: DOMMatrix2DInit): void
+  transform(a: number, b: number, c: number, d: number, e: number, f: number): void
+  translate(x: number, y: number): void
+}
+type PredefinedColorSpace = 'display-p3' | 'srgb'
+
+interface ImageDataSettings {
+  colorSpace?: PredefinedColorSpace
+}
+interface CanvasImageData {
+  createImageData(sw: number, sh: number, settings?: ImageDataSettings): ImageData
+  createImageData(imagedata: ImageData): ImageData
+  getImageData(sx: number, sy: number, sw: number, sh: number, settings?: ImageDataSettings): ImageData
+  putImageData(imagedata: ImageData, dx: number, dy: number): void
+  putImageData(
+    imagedata: ImageData,
+    dx: number,
+    dy: number,
+    dirtyX: number,
+    dirtyY: number,
+    dirtyWidth: number,
+    dirtyHeight: number,
+  ): void
+}
+
+type CanvasDirection = 'inherit' | 'ltr' | 'rtl'
+type CanvasFontKerning = 'auto' | 'none' | 'normal'
+type CanvasFontStretch =
+  | 'condensed'
+  | 'expanded'
+  | 'extra-condensed'
+  | 'extra-expanded'
+  | 'normal'
+  | 'semi-condensed'
+  | 'semi-expanded'
+  | 'ultra-condensed'
+  | 'ultra-expanded'
+type CanvasFontVariantCaps =
+  | 'all-petite-caps'
+  | 'all-small-caps'
+  | 'normal'
+  | 'petite-caps'
+  | 'small-caps'
+  | 'titling-caps'
+  | 'unicase'
+type CanvasTextAlign = 'center' | 'end' | 'left' | 'right' | 'start'
+type CanvasTextBaseline = 'alphabetic' | 'bottom' | 'hanging' | 'ideographic' | 'middle' | 'top'
+type CanvasTextRendering = 'auto' | 'geometricPrecision' | 'optimizeLegibility' | 'optimizeSpeed'
+
+interface CanvasTextDrawingStyles {
+  direction: CanvasDirection
+  font: string
+  fontKerning: CanvasFontKerning
+  fontStretch: CanvasFontStretch
+  fontVariantCaps: CanvasFontVariantCaps
+  letterSpacing: string
+  textAlign: CanvasTextAlign
+  textBaseline: CanvasTextBaseline
+  textRendering: CanvasTextRendering
+  wordSpacing: string
+}
+
+interface CanvasFilters {
+  filter: string
+}
+
+interface CanvasFillStrokeStyles {
+  fillStyle: string | CanvasGradient | CanvasPattern
+  strokeStyle: string | CanvasGradient | CanvasPattern
+  createConicGradient(startAngle: number, x: number, y: number): CanvasGradient
+  createLinearGradient(x0: number, y0: number, x1: number, y1: number): CanvasGradient
+  createRadialGradient(x0: number, y0: number, r0: number, x1: number, y1: number, r1: number): CanvasGradient
+}
+
+type CanvasFillRule = 'evenodd' | 'nonzero'
+
+interface CanvasDrawPath {
+  beginPath(): void
+  clip(fillRule?: CanvasFillRule): void
+  clip(path: Path2D, fillRule?: CanvasFillRule): void
+  fill(fillRule?: CanvasFillRule): void
+  fill(path: Path2D, fillRule?: CanvasFillRule): void
+  isPointInPath(x: number, y: number, fillRule?: CanvasFillRule): boolean
+  isPointInPath(path: Path2D, x: number, y: number, fillRule?: CanvasFillRule): boolean
+  isPointInStroke(x: number, y: number): boolean
+  isPointInStroke(path: Path2D, x: number, y: number): boolean
+  stroke(): void
+  stroke(path: Path2D): void
+}
+
+type GlobalCompositeOperation =
+  | 'color'
+  | 'color-burn'
+  | 'color-dodge'
+  | 'copy'
+  | 'darken'
+  | 'destination-atop'
+  | 'destination-in'
+  | 'destination-out'
+  | 'destination-over'
+  | 'difference'
+  | 'exclusion'
+  | 'hard-light'
+  | 'hue'
+  | 'lighten'
+  | 'lighter'
+  | 'luminosity'
+  | 'multiply'
+  | 'overlay'
+  | 'saturation'
+  | 'screen'
+  | 'soft-light'
+  | 'source-atop'
+  | 'source-in'
+  | 'source-out'
+  | 'source-over'
+  | 'xor'
+
+interface CanvasCompositing {
+  globalAlpha: number
+  globalCompositeOperation: GlobalCompositeOperation
+}
+
+interface DOMPointInit {
+  w?: number
+  x?: number
+  y?: number
+  z?: number
+}
+interface CanvasPattern {
+  setTransform(transform?: DOMMatrix2DInit): void
+}
+
+interface CanvasGradient {
+  addColorStop(offset: number, color: string): void
+}
+
+interface DOMRectInit {
+  height?: number
+  width?: number
+  x?: number
+  y?: number
+}
+
+interface DOMMatrixInit extends DOMMatrix2DInit {
+  is2D?: boolean
+  m13?: number
+  m14?: number
+  m23?: number
+  m24?: number
+  m31?: number
+  m32?: number
+  m33?: number
+  m34?: number
+  m43?: number
+  m44?: number
+}
+
+// ----------- added types
+
 export interface DOMMatrix2DInit {
   a: number
   b: number
@@ -250,11 +523,7 @@ export interface StrokeOptions {
   join?: StrokeJoin
 }
 
-export interface SKRSContext2D
-  extends Omit<
-    CanvasRenderingContext2D,
-    'drawImage' | 'createPattern' | 'getTransform' | 'drawFocusIfNeeded' | 'scrollPathIntoView' | 'canvas'
-  > {
+export interface SKRSContext2D extends CanvasRenderingContext2D {
   canvas: Canvas
   /**
    * @param startAngle The angle at which to begin the gradient, in radians. Angle measurements start vertically above the centre and move around clockwise.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "allowJs": true,
     "outDir": "dist",
     "sourceMap": true,
-    "lib": ["ESNext", "DOM"]
+    "lib": ["ESNext"]
   },
   "exclude": ["node_modules", "depot_tools", "skia", "skia-c", "example", "target", "npm"]
 }


### PR DESCRIPTION
This allows code that depends on @napi-rs/canvas to not include DOM types while typechecking