### PR TITLE
feat: add GIF encoding support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ anyhow          = "1"
 base64-simd     = "0.8"
 cssparser       = "0.35"
 cssparser-color = "0.3"
+gif             = "0.14"
 infer           = "0.19"
 libavif         = { version = "0.14", default-features = false, features = ["codec-aom"] }
 libavif-sys     = { version = "0.17", default-features = false, features = ["codec-aom"] }

--- a/__test__/gif.spec.ts
+++ b/__test__/gif.spec.ts
@@ -1,0 +1,460 @@
+import test from 'ava'
+
+import { createCanvas, GifEncoder, GifDisposal } from '../index'
+
+// GIF magic bytes: GIF87a or GIF89a
+const GIF_MAGIC = Buffer.from([0x47, 0x49, 0x46, 0x38]) // "GIF8"
+
+function isValidGif(buffer: Buffer): boolean {
+  return buffer.length > 4 && buffer.subarray(0, 4).equals(GIF_MAGIC)
+}
+
+// Single-frame GIF encoding tests
+
+test('encode single-frame GIF using canvas.encode()', async (t) => {
+  const canvas = createCanvas(100, 100)
+  const ctx = canvas.getContext('2d')
+
+  ctx.fillStyle = 'red'
+  ctx.fillRect(0, 0, 100, 100)
+
+  const buffer = await canvas.encode('gif')
+  t.true(Buffer.isBuffer(buffer))
+  t.true(buffer.length > 0)
+  t.true(isValidGif(buffer))
+})
+
+test('encode single-frame GIF with quality option', async (t) => {
+  const canvas = createCanvas(100, 100)
+  const ctx = canvas.getContext('2d')
+
+  ctx.fillStyle = 'blue'
+  ctx.fillRect(0, 0, 100, 100)
+
+  const bufferLowQuality = await canvas.encode('gif', 30)
+  const bufferHighQuality = await canvas.encode('gif', 1)
+
+  t.true(isValidGif(bufferLowQuality))
+  t.true(isValidGif(bufferHighQuality))
+  // Higher quality (lower number) should generally produce similar or larger files
+  // due to more accurate color quantization
+  t.true(bufferLowQuality.length > 0)
+  t.true(bufferHighQuality.length > 0)
+})
+
+test('toDataURL with image/gif MIME type', (t) => {
+  const canvas = createCanvas(50, 50)
+  const ctx = canvas.getContext('2d')
+
+  ctx.fillStyle = 'green'
+  ctx.fillRect(0, 0, 50, 50)
+
+  const dataUrl = canvas.toDataURL('image/gif')
+  t.true(dataUrl.startsWith('data:image/gif;base64,'))
+
+  // Decode and verify it's a valid GIF
+  const base64Data = dataUrl.split(',')[1]
+  const buffer = Buffer.from(base64Data, 'base64')
+  t.true(isValidGif(buffer))
+})
+
+test('toDataURLAsync with image/gif MIME type', async (t) => {
+  const canvas = createCanvas(50, 50)
+  const ctx = canvas.getContext('2d')
+
+  ctx.fillStyle = 'yellow'
+  ctx.fillRect(0, 0, 50, 50)
+
+  const dataUrl = await canvas.toDataURLAsync('image/gif')
+  t.true(dataUrl.startsWith('data:image/gif;base64,'))
+
+  const base64Data = dataUrl.split(',')[1]
+  const buffer = Buffer.from(base64Data, 'base64')
+  t.true(isValidGif(buffer))
+})
+
+test('toBuffer with image/gif MIME type', (t) => {
+  const canvas = createCanvas(50, 50)
+  const ctx = canvas.getContext('2d')
+
+  ctx.fillStyle = 'purple'
+  ctx.fillRect(0, 0, 50, 50)
+
+  const buffer = canvas.toBuffer('image/gif')
+  t.true(Buffer.isBuffer(buffer))
+  t.true(isValidGif(buffer))
+})
+
+test('toBlob with image/gif MIME type', async (t) => {
+  const canvas = createCanvas(50, 50)
+  const ctx = canvas.getContext('2d')
+
+  ctx.fillStyle = 'orange'
+  ctx.fillRect(0, 0, 50, 50)
+
+  return new Promise<void>((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        try {
+          t.truthy(blob)
+          t.true(blob instanceof Blob)
+          t.true(blob!.size > 0)
+          resolve()
+        } catch (error) {
+          reject(error)
+        }
+      },
+      'image/gif',
+    )
+  })
+})
+
+test('convertToBlob with image/gif MIME type', async (t) => {
+  const canvas = createCanvas(50, 50)
+  const ctx = canvas.getContext('2d')
+
+  ctx.fillStyle = 'cyan'
+  ctx.fillRect(0, 0, 50, 50)
+
+  const blob = await canvas.convertToBlob({ mime: 'image/gif' })
+  t.truthy(blob)
+  t.true(blob instanceof Blob)
+  t.true(blob.size > 0)
+})
+
+// GifEncoder (animated GIF) tests
+
+test('GifEncoder constructor', (t) => {
+  const encoder = new GifEncoder(100, 100)
+  t.truthy(encoder)
+  t.is(encoder.width, 100)
+  t.is(encoder.height, 100)
+  t.is(encoder.frameCount, 0)
+})
+
+test('GifEncoder with config options', (t) => {
+  const encoder = new GifEncoder(200, 150, {
+    repeat: 0,
+    quality: 10,
+  })
+  t.truthy(encoder)
+  t.is(encoder.width, 200)
+  t.is(encoder.height, 150)
+})
+
+test('GifEncoder.addFrame with RGBA data', (t) => {
+  const encoder = new GifEncoder(10, 10)
+
+  // Create a 10x10 red RGBA image
+  const rgbaData = new Uint8Array(10 * 10 * 4)
+  for (let i = 0; i < 10 * 10; i++) {
+    rgbaData[i * 4 + 0] = 255 // R
+    rgbaData[i * 4 + 1] = 0   // G
+    rgbaData[i * 4 + 2] = 0   // B
+    rgbaData[i * 4 + 3] = 255 // A
+  }
+
+  encoder.addFrame(rgbaData, 10, 10, { delay: 100 })
+  t.is(encoder.frameCount, 1)
+})
+
+test('GifEncoder.finish produces valid GIF', (t) => {
+  const encoder = new GifEncoder(10, 10)
+
+  // Red frame
+  const redFrame = new Uint8Array(10 * 10 * 4)
+  for (let i = 0; i < 10 * 10; i++) {
+    redFrame[i * 4 + 0] = 255
+    redFrame[i * 4 + 1] = 0
+    redFrame[i * 4 + 2] = 0
+    redFrame[i * 4 + 3] = 255
+  }
+
+  encoder.addFrame(redFrame, 10, 10, { delay: 100 })
+
+  const buffer = encoder.finish()
+  t.true(Buffer.isBuffer(buffer))
+  t.true(isValidGif(buffer))
+})
+
+test('GifEncoder creates animated GIF with multiple frames', (t) => {
+  const encoder = new GifEncoder(10, 10, { repeat: 0 })
+
+  // Red frame
+  const redFrame = new Uint8Array(10 * 10 * 4)
+  for (let i = 0; i < 10 * 10; i++) {
+    redFrame[i * 4 + 0] = 255
+    redFrame[i * 4 + 1] = 0
+    redFrame[i * 4 + 2] = 0
+    redFrame[i * 4 + 3] = 255
+  }
+
+  // Blue frame
+  const blueFrame = new Uint8Array(10 * 10 * 4)
+  for (let i = 0; i < 10 * 10; i++) {
+    blueFrame[i * 4 + 0] = 0
+    blueFrame[i * 4 + 1] = 0
+    blueFrame[i * 4 + 2] = 255
+    blueFrame[i * 4 + 3] = 255
+  }
+
+  // Green frame
+  const greenFrame = new Uint8Array(10 * 10 * 4)
+  for (let i = 0; i < 10 * 10; i++) {
+    greenFrame[i * 4 + 0] = 0
+    greenFrame[i * 4 + 1] = 255
+    greenFrame[i * 4 + 2] = 0
+    greenFrame[i * 4 + 3] = 255
+  }
+
+  encoder.addFrame(redFrame, 10, 10, { delay: 500 })
+  encoder.addFrame(blueFrame, 10, 10, { delay: 500 })
+  encoder.addFrame(greenFrame, 10, 10, { delay: 500 })
+
+  t.is(encoder.frameCount, 3)
+
+  const buffer = encoder.finish()
+  t.true(isValidGif(buffer))
+  // Animated GIF should be larger than single frame
+  t.true(buffer.length > 100)
+})
+
+test('GifEncoder with disposal methods', (t) => {
+  const encoder = new GifEncoder(10, 10, { repeat: 0 })
+
+  const frame = new Uint8Array(10 * 10 * 4)
+  for (let i = 0; i < 10 * 10; i++) {
+    frame[i * 4 + 0] = 255
+    frame[i * 4 + 1] = 0
+    frame[i * 4 + 2] = 0
+    frame[i * 4 + 3] = 255
+  }
+
+  encoder.addFrame(frame, 10, 10, { delay: 100, disposal: GifDisposal.Keep })
+  encoder.addFrame(frame, 10, 10, { delay: 100, disposal: GifDisposal.Background })
+  encoder.addFrame(frame, 10, 10, { delay: 100, disposal: GifDisposal.Previous })
+
+  const buffer = encoder.finish()
+  t.true(isValidGif(buffer))
+})
+
+test('GifEncoder with frame offset (left/top)', (t) => {
+  const encoder = new GifEncoder(20, 20, { repeat: 0 })
+
+  // Small 5x5 frame
+  const smallFrame = new Uint8Array(5 * 5 * 4)
+  for (let i = 0; i < 5 * 5; i++) {
+    smallFrame[i * 4 + 0] = 255
+    smallFrame[i * 4 + 1] = 0
+    smallFrame[i * 4 + 2] = 0
+    smallFrame[i * 4 + 3] = 255
+  }
+
+  encoder.addFrame(smallFrame, 5, 5, { delay: 100, left: 0, top: 0 })
+  encoder.addFrame(smallFrame, 5, 5, { delay: 100, left: 5, top: 5 })
+  encoder.addFrame(smallFrame, 5, 5, { delay: 100, left: 10, top: 10 })
+
+  const buffer = encoder.finish()
+  t.true(isValidGif(buffer))
+})
+
+test('GifEncoder throws error with no frames', (t) => {
+  const encoder = new GifEncoder(10, 10)
+
+  const error = t.throws(() => {
+    encoder.finish()
+  })
+  t.truthy(error)
+})
+
+test('GifEncoder throws error with invalid data length', (t) => {
+  const encoder = new GifEncoder(10, 10)
+
+  // Wrong size data (should be 10*10*4 = 400 bytes)
+  const wrongData = new Uint8Array(100)
+
+  const error = t.throws(() => {
+    encoder.addFrame(wrongData, 10, 10)
+  })
+  t.truthy(error)
+})
+
+test('GifEncoder clears frames after finish()', (t) => {
+  const encoder = new GifEncoder(10, 10)
+
+  const frame = new Uint8Array(10 * 10 * 4)
+  for (let i = 0; i < 10 * 10; i++) {
+    frame[i * 4 + 0] = 255
+    frame[i * 4 + 1] = 0
+    frame[i * 4 + 2] = 0
+    frame[i * 4 + 3] = 255
+  }
+
+  encoder.addFrame(frame, 10, 10, { delay: 100 })
+  t.is(encoder.frameCount, 1)
+
+  encoder.finish()
+  t.is(encoder.frameCount, 0)
+})
+
+test('GifEncoder with finite repeat count', (t) => {
+  const encoder = new GifEncoder(10, 10, { repeat: 3 }) // Play 3 times
+
+  const frame = new Uint8Array(10 * 10 * 4)
+  for (let i = 0; i < 10 * 10; i++) {
+    frame[i * 4 + 0] = 128
+    frame[i * 4 + 1] = 128
+    frame[i * 4 + 2] = 128
+    frame[i * 4 + 3] = 255
+  }
+
+  encoder.addFrame(frame, 10, 10, { delay: 100 })
+  encoder.addFrame(frame, 10, 10, { delay: 100 })
+
+  const buffer = encoder.finish()
+  t.true(isValidGif(buffer))
+})
+
+// Test with canvas-drawn content
+
+test('GifEncoder with canvas-drawn frames', (t) => {
+  const width = 50
+  const height = 50
+  const encoder = new GifEncoder(width, height, { repeat: 0, quality: 10 })
+
+  const canvas = createCanvas(width, height)
+  const ctx = canvas.getContext('2d')
+
+  // Frame 1: Red circle
+  ctx.fillStyle = 'white'
+  ctx.fillRect(0, 0, width, height)
+  ctx.fillStyle = 'red'
+  ctx.beginPath()
+  ctx.arc(25, 25, 20, 0, Math.PI * 2)
+  ctx.fill()
+
+  let imageData = ctx.getImageData(0, 0, width, height)
+  encoder.addFrame(new Uint8Array(imageData.data.buffer), width, height, { delay: 200 })
+
+  // Frame 2: Blue circle
+  ctx.fillStyle = 'white'
+  ctx.fillRect(0, 0, width, height)
+  ctx.fillStyle = 'blue'
+  ctx.beginPath()
+  ctx.arc(25, 25, 20, 0, Math.PI * 2)
+  ctx.fill()
+
+  imageData = ctx.getImageData(0, 0, width, height)
+  encoder.addFrame(new Uint8Array(imageData.data.buffer), width, height, { delay: 200 })
+
+  // Frame 3: Green circle
+  ctx.fillStyle = 'white'
+  ctx.fillRect(0, 0, width, height)
+  ctx.fillStyle = 'green'
+  ctx.beginPath()
+  ctx.arc(25, 25, 20, 0, Math.PI * 2)
+  ctx.fill()
+
+  imageData = ctx.getImageData(0, 0, width, height)
+  encoder.addFrame(new Uint8Array(imageData.data.buffer), width, height, { delay: 200 })
+
+  t.is(encoder.frameCount, 3)
+
+  const buffer = encoder.finish()
+  t.true(isValidGif(buffer))
+  t.true(buffer.length > 500) // Should be reasonably sized
+})
+
+test('GifEncoder with transparency', (t) => {
+  const encoder = new GifEncoder(10, 10, { repeat: 0 })
+
+  // Frame with semi-transparent pixels
+  const frame = new Uint8Array(10 * 10 * 4)
+  for (let i = 0; i < 10 * 10; i++) {
+    frame[i * 4 + 0] = 255
+    frame[i * 4 + 1] = 0
+    frame[i * 4 + 2] = 0
+    frame[i * 4 + 3] = i < 50 ? 0 : 255 // Half transparent, half opaque
+  }
+
+  encoder.addFrame(frame, 10, 10, { delay: 100 })
+
+  const buffer = encoder.finish()
+  t.true(isValidGif(buffer))
+})
+
+test('encode GIF with gradient (color quantization test)', async (t) => {
+  const canvas = createCanvas(100, 100)
+  const ctx = canvas.getContext('2d')
+
+  // Create a gradient with many colors
+  const gradient = ctx.createLinearGradient(0, 0, 100, 100)
+  gradient.addColorStop(0, 'red')
+  gradient.addColorStop(0.25, 'yellow')
+  gradient.addColorStop(0.5, 'green')
+  gradient.addColorStop(0.75, 'blue')
+  gradient.addColorStop(1, 'purple')
+
+  ctx.fillStyle = gradient
+  ctx.fillRect(0, 0, 100, 100)
+
+  // GIF can only have 256 colors, so this tests the color quantization
+  const buffer = await canvas.encode('gif', 10)
+  t.true(isValidGif(buffer))
+  t.true(buffer.length > 0)
+})
+
+// Symbol.dispose tests
+
+test('GifEncoder.dispose() clears frames', (t) => {
+  const encoder = new GifEncoder(10, 10)
+
+  const frame = new Uint8Array(10 * 10 * 4)
+  for (let i = 0; i < 10 * 10; i++) {
+    frame[i * 4 + 0] = 255
+    frame[i * 4 + 1] = 0
+    frame[i * 4 + 2] = 0
+    frame[i * 4 + 3] = 255
+  }
+
+  encoder.addFrame(frame, 10, 10, { delay: 100 })
+  t.is(encoder.frameCount, 1)
+
+  encoder.dispose()
+  t.is(encoder.frameCount, 0)
+})
+
+test('GifEncoder has Symbol.dispose method', (t) => {
+  // Symbol.dispose is available in Node.js 20+ with --harmony flag or Node.js 22+
+  if (typeof Symbol.dispose === 'undefined') {
+    t.pass('Symbol.dispose not available in this Node.js version, skipping')
+    return
+  }
+
+  const encoder = new GifEncoder(10, 10)
+  t.true(typeof (encoder as any)[Symbol.dispose] === 'function')
+})
+
+test('GifEncoder Symbol.dispose calls dispose()', (t) => {
+  if (typeof Symbol.dispose === 'undefined') {
+    t.pass('Symbol.dispose not available in this Node.js version, skipping')
+    return
+  }
+
+  const encoder = new GifEncoder(10, 10)
+
+  const frame = new Uint8Array(10 * 10 * 4)
+  for (let i = 0; i < 10 * 10; i++) {
+    frame[i * 4 + 0] = 255
+    frame[i * 4 + 1] = 0
+    frame[i * 4 + 2] = 0
+    frame[i * 4 + 3] = 255
+  }
+
+  encoder.addFrame(frame, 10, 10, { delay: 100 })
+  t.is(encoder.frameCount, 1)
+
+  // Call Symbol.dispose directly
+  ;(encoder as any)[Symbol.dispose]()
+  t.is(encoder.frameCount, 0)
+})

--- a/index.js
+++ b/index.js
@@ -17,11 +17,20 @@ const {
   StrokeCap,
   convertSVGTextToPath,
   PdfDocument,
+  GifEncoder,
+  GifDisposal,
 } = require('./js-binding')
 
 const { DOMPoint, DOMMatrix, DOMRect } = require('./geometry')
 
 const loadImage = require('./load-image')
+
+// Add Symbol.dispose support for GifEncoder (ECMAScript 2024 Explicit Resource Management)
+if (GifEncoder && typeof Symbol.dispose !== 'undefined') {
+  GifEncoder.prototype[Symbol.dispose] = function () {
+    this.dispose()
+  }
+}
 
 const SvgExportFlag = {
   ConvertTextToPaths: 0x01,
@@ -178,4 +187,7 @@ module.exports = {
   CanvasElement,
   SVGCanvas,
   PDFDocument: PdfDocument,
+  // GIF encoding
+  GifEncoder,
+  GifDisposal,
 }

--- a/js-binding.js
+++ b/js-binding.js
@@ -460,3 +460,5 @@ module.exports.PathOp = nativeBinding.PathOp
 module.exports.StrokeCap = nativeBinding.StrokeCap
 module.exports.StrokeJoin = nativeBinding.StrokeJoin
 module.exports.SvgExportFlag = nativeBinding.SvgExportFlag
+module.exports.GifEncoder = nativeBinding.GifEncoder
+module.exports.GifDisposal = nativeBinding.GifDisposal

--- a/src/gif.rs
+++ b/src/gif.rs
@@ -1,0 +1,317 @@
+use gif::{DisposalMethod, Encoder, Frame, Repeat};
+use napi::bindgen_prelude::*;
+use napi_derive::napi;
+
+use crate::error::SkError;
+use crate::sk::SurfaceRef;
+
+/// GIF encoding configuration for single-frame encoding
+#[napi(object)]
+#[derive(Default, Clone)]
+pub struct GifConfig {
+  /// Quality for NeuQuant color quantization (1-30, lower = slower but better quality)
+  /// Default: 10
+  pub quality: Option<u32>,
+}
+
+/// Configuration for the GIF encoder (animated GIFs)
+#[napi(object)]
+#[derive(Default, Clone)]
+pub struct GifEncoderConfig {
+  /// Loop count: 0 = infinite loop, positive number = finite loops
+  /// Default: 0 (infinite)
+  pub repeat: Option<i32>,
+  /// Quality for NeuQuant color quantization (1-30, lower = slower but better quality)
+  /// Default: 10
+  pub quality: Option<u32>,
+}
+
+/// Configuration for individual GIF frames
+#[napi(object)]
+#[derive(Default, Clone)]
+pub struct GifFrameConfig {
+  /// Frame delay in milliseconds
+  /// Default: 100 (100ms = 10 centiseconds)
+  pub delay: Option<u32>,
+  /// Disposal method for this frame
+  pub disposal: Option<GifDisposal>,
+  /// Transparent color index (0-255), if the frame has transparency
+  pub transparent: Option<u32>,
+  /// X offset of this frame within the canvas
+  pub left: Option<u32>,
+  /// Y offset of this frame within the canvas
+  pub top: Option<u32>,
+}
+
+/// GIF frame disposal method
+#[napi]
+#[derive(Clone, Copy, Default)]
+pub enum GifDisposal {
+  /// Keep the frame visible (default)
+  #[default]
+  Keep,
+  /// Clear the frame area to the background color
+  Background,
+  /// Restore to the previous frame
+  Previous,
+}
+
+impl From<GifDisposal> for DisposalMethod {
+  fn from(disposal: GifDisposal) -> Self {
+    match disposal {
+      GifDisposal::Keep => DisposalMethod::Keep,
+      GifDisposal::Background => DisposalMethod::Background,
+      GifDisposal::Previous => DisposalMethod::Previous,
+    }
+  }
+}
+
+struct GifFrameData {
+  pixels: Vec<u8>,
+  width: u16,
+  height: u16,
+  delay: u16,
+  disposal: DisposalMethod,
+  transparent: Option<u8>,
+  left: u16,
+  top: u16,
+}
+
+/// GIF Encoder for creating animated GIFs
+///
+/// Example usage:
+/// ```javascript
+/// const encoder = new GifEncoder(800, 600, { repeat: 0, quality: 10 });
+///
+/// // Draw first frame
+/// ctx.fillStyle = 'red';
+/// ctx.fillRect(0, 0, 800, 600);
+/// encoder.addFrame(canvas, { delay: 100 });
+///
+/// // Draw second frame
+/// ctx.fillStyle = 'blue';
+/// ctx.fillRect(0, 0, 800, 600);
+/// encoder.addFrame(canvas, { delay: 100 });
+///
+/// // Encode
+/// const buffer = encoder.finish();
+/// ```
+#[napi]
+pub struct GifEncoder {
+  width: u16,
+  height: u16,
+  frames: Vec<GifFrameData>,
+  repeat: Repeat,
+  quality: i32,
+}
+
+#[napi]
+impl GifEncoder {
+  /// Create a new GIF encoder with the specified dimensions
+  #[napi(constructor)]
+  pub fn new(width: u32, height: u32, config: Option<GifEncoderConfig>) -> Self {
+    let config = config.unwrap_or_default();
+    let repeat = match config.repeat {
+      Some(0) | None => Repeat::Infinite,
+      Some(n) if n > 0 => Repeat::Finite(n as u16),
+      Some(_) => Repeat::Infinite,
+    };
+    let quality = config.quality.unwrap_or(10).clamp(1, 30) as i32;
+
+    GifEncoder {
+      width: width as u16,
+      height: height as u16,
+      frames: Vec::new(),
+      repeat,
+      quality,
+    }
+  }
+
+  /// Add a frame from RGBA pixel data
+  ///
+  /// The data must be width * height * 4 bytes (RGBA format)
+  #[napi]
+  pub fn add_frame(
+    &mut self,
+    data: Uint8Array,
+    width: u32,
+    height: u32,
+    config: Option<GifFrameConfig>,
+  ) -> Result<()> {
+    let config = config.unwrap_or_default();
+    let expected_len = (width as usize) * (height as usize) * 4;
+
+    if data.len() != expected_len {
+      return Err(Error::new(
+        Status::InvalidArg,
+        format!(
+          "Invalid data length: expected {} bytes for {}x{} RGBA image, got {}",
+          expected_len,
+          width,
+          height,
+          data.len()
+        ),
+      ));
+    }
+
+    // GIF delay is in centiseconds (1/100th of a second)
+    let delay_ms = config.delay.unwrap_or(100);
+    let delay_cs = (delay_ms / 10) as u16;
+
+    let frame_data = GifFrameData {
+      pixels: data.to_vec(),
+      width: width as u16,
+      height: height as u16,
+      delay: delay_cs.max(1), // Minimum 1 centisecond
+      disposal: config.disposal.unwrap_or_default().into(),
+      transparent: config.transparent.map(|t| t as u8),
+      left: config.left.unwrap_or(0) as u16,
+      top: config.top.unwrap_or(0) as u16,
+    };
+
+    self.frames.push(frame_data);
+    Ok(())
+  }
+
+  /// Get the number of frames added so far
+  #[napi(getter)]
+  pub fn frame_count(&self) -> u32 {
+    self.frames.len() as u32
+  }
+
+  /// Get the width of the GIF canvas
+  #[napi(getter)]
+  pub fn width(&self) -> u32 {
+    self.width as u32
+  }
+
+  /// Get the height of the GIF canvas
+  #[napi(getter)]
+  pub fn height(&self) -> u32 {
+    self.height as u32
+  }
+
+  /// Finish encoding and return the GIF data
+  #[napi]
+  pub fn finish(&mut self) -> Result<Buffer> {
+    if self.frames.is_empty() {
+      return Err(Error::new(
+        Status::InvalidArg,
+        "Cannot encode GIF with no frames".to_owned(),
+      ));
+    }
+
+    let data = encode_gif_frames(
+      &self.frames,
+      self.width,
+      self.height,
+      self.repeat,
+      self.quality,
+    )
+    .map_err(|e| Error::new(Status::GenericFailure, format!("GIF encoding failed: {e}")))?;
+
+    // Clear frames after encoding
+    self.frames.clear();
+
+    Ok(data.into())
+  }
+
+  /// Dispose of the encoder, clearing all accumulated frames without encoding.
+  /// This is called automatically when using the `using` keyword (Symbol.dispose).
+  ///
+  /// Example:
+  /// ```javascript
+  /// {
+  ///   using encoder = new GifEncoder(100, 100);
+  ///   encoder.addFrame(data, 100, 100);
+  ///   // If an error is thrown here, frames are automatically cleaned up
+  ///   const buffer = encoder.finish();
+  /// } // encoder.dispose() called automatically
+  /// ```
+  #[napi]
+  pub fn dispose(&mut self) {
+    self.frames.clear();
+  }
+}
+
+/// Encode multiple frames into an animated GIF
+fn encode_gif_frames(
+  frames: &[GifFrameData],
+  width: u16,
+  height: u16,
+  repeat: Repeat,
+  quality: i32,
+) -> std::result::Result<Vec<u8>, SkError> {
+  let mut buffer = Vec::new();
+
+  {
+    let mut encoder = Encoder::new(&mut buffer, width, height, &[])
+      .map_err(|e| SkError::Generic(format!("Failed to create GIF encoder: {e}")))?;
+
+    encoder
+      .set_repeat(repeat)
+      .map_err(|e| SkError::Generic(format!("Failed to set repeat: {e}")))?;
+
+    for frame_data in frames {
+      let mut pixels = frame_data.pixels.clone();
+
+      let mut frame =
+        Frame::from_rgba_speed(frame_data.width, frame_data.height, &mut pixels, quality);
+
+      frame.delay = frame_data.delay;
+      frame.dispose = frame_data.disposal;
+      frame.left = frame_data.left;
+      frame.top = frame_data.top;
+
+      if let Some(transparent) = frame_data.transparent {
+        frame.transparent = Some(transparent);
+      }
+
+      encoder
+        .write_frame(&frame)
+        .map_err(|e| SkError::Generic(format!("Failed to write frame: {e}")))?;
+    }
+  }
+
+  Ok(buffer)
+}
+
+/// Encode a single frame as a static GIF
+pub(crate) fn encode(
+  pixels: &[u8],
+  width: u32,
+  height: u32,
+  config: &GifConfig,
+) -> std::result::Result<Vec<u8>, SkError> {
+  let quality = config.quality.unwrap_or(10).clamp(1, 30) as i32;
+  let mut pixels = pixels.to_vec();
+
+  let frame = Frame::from_rgba_speed(width as u16, height as u16, &mut pixels, quality);
+
+  let mut buffer = Vec::new();
+  {
+    let mut encoder = Encoder::new(&mut buffer, width as u16, height as u16, &[])
+      .map_err(|e| SkError::Generic(format!("Failed to create GIF encoder: {e}")))?;
+
+    encoder
+      .write_frame(&frame)
+      .map_err(|e| SkError::Generic(format!("Failed to write frame: {e}")))?;
+  }
+
+  Ok(buffer)
+}
+
+/// Encode a surface reference as a static GIF
+pub(crate) fn encode_surface(
+  surface: &SurfaceRef,
+  width: u32,
+  height: u32,
+  config: &GifConfig,
+) -> std::result::Result<Vec<u8>, SkError> {
+  let (data, size) = surface
+    .data()
+    .ok_or_else(|| SkError::Generic("Failed to get surface pixels for GIF encoding".to_owned()))?;
+
+  let pixels = unsafe { std::slice::from_raw_parts(data, size) };
+  encode(pixels, width, height, config)
+}


### PR DESCRIPTION
- Add `gif` crate (0.14) for GIF encoding with NeuQuant color quantization
- Support single-frame GIF encoding via existing Canvas APIs:
  - `canvas.encode('gif', quality)`
  - `canvas.toBuffer('image/gif')`
  - `canvas.toDataURL('image/gif')`
- Add `GifEncoder` class for animated GIF creation:
  - `addFrame(data, width, height, config)` - add RGBA frames
  - `finish()` - encode and return GIF buffer
  - `dispose()` - cleanup without encoding
- Implement `Symbol.dispose` for ES2024 `using` keyword support
- Add comprehensive TypeScript definitions
- Add 24 tests covering all GIF functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)