### PR TITLE
chore: update Rust toolchain

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,11 @@
     {
       "automerge": true,
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"]
+    },
+    {
+      "groupName": "rust toolchain",
+      "matchManagers": ["custom.regex"],
+      "matchDepNames": ["rustc"]
     }
   ],
   "lockFileMaintenance": {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.91.1"
+channel = "1.92.0"
 profile = "default"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Rust toolchain update**
> 
> - Bumps `rust-toolchain.toml` `channel` from `1.91.1` to `1.92.0`.
> 
> **Renovate configuration**
> 
> - Adds a `packageRules` group named `rust toolchain` in `renovate.json` to group `rustc` updates via `custom.regex` manager.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f8d12de166046a6e4c0a41d1ab9aec2c157dcde. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->