### PR TITLE
fix: add Drop impl for SkPictureRecorder to prevent memory leak

### DIFF
--- a/skia-c/skia_c.cpp
+++ b/skia-c/skia_c.cpp
@@ -1075,6 +1075,11 @@ skiac_picture_recorder* skiac_picture_recorder_create() {
   return reinterpret_cast<skiac_picture_recorder*>(new SkPictureRecorder());
 }
 
+void skiac_picture_recorder_destroy(
+    skiac_picture_recorder* c_picture_recorder) {
+  delete reinterpret_cast<SkPictureRecorder*>(c_picture_recorder);
+}
+
 void skiac_picture_recorder_begin_recording(
     skiac_picture_recorder* c_picture_recorder,
     float x,

--- a/skia-c/skia_c.hpp
+++ b/skia-c/skia_c.hpp
@@ -1269,6 +1269,7 @@ void skiac_picture_ref(skiac_picture* c_picture);
 void skiac_picture_destroy(skiac_picture* c_picture);
 void skiac_picture_playback(skiac_picture* c_picture, skiac_canvas* c_canvas);
 skiac_picture_recorder* skiac_picture_recorder_create();
+void skiac_picture_recorder_destroy(skiac_picture_recorder* c_picture_recorder);
 void skiac_picture_recorder_begin_recording(
     skiac_picture_recorder* c_picture_recorder,
     float x,

--- a/src/sk.rs
+++ b/src/sk.rs
@@ -1128,6 +1128,7 @@ pub mod ffi {
 
     // SkPictureRecorder
     pub fn skiac_picture_recorder_create() -> *mut skiac_picture_recorder;
+    pub fn skiac_picture_recorder_destroy(picture_recorder: *mut skiac_picture_recorder);
 
     pub fn skiac_picture_recorder_begin_recording(
       picture_recorder: *mut skiac_picture_recorder,
@@ -4583,6 +4584,16 @@ impl Drop for SkDrawable {
 
 #[derive(Debug)]
 pub struct SkPictureRecorder(pub(crate) *mut ffi::skiac_picture_recorder);
+
+impl Drop for SkPictureRecorder {
+  fn drop(&mut self) {
+    if !self.0.is_null() {
+      unsafe {
+        ffi::skiac_picture_recorder_destroy(self.0);
+      }
+    }
+  }
+}
 
 impl SkPictureRecorder {
   pub fn new() -> SkPictureRecorder {


### PR DESCRIPTION
SkPictureRecorder was the only Skia FFI wrapper type missing a Drop
implementation. The C++ SkPictureRecorder* allocated with `new` was
never `delete`d, leaking ~5.4 KB per instance.

Temporary PictureRecorders are created in render_canvas() for blend
modes like destination-out, destination-in, source-in, etc. — one per
draw call. In game loops at 20fps this leaked ~380 MB/hour.

Fixes #1196

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized lifecycle change in the Rust/C++ FFI boundary; main risk is accidental double-free or freeing while still in use, but it follows the existing explicit-`destroy` pattern.
> 
> **Overview**
> Prevents a memory leak in the Skia Rust bindings by adding a destructor path for `SkPictureRecorder`.
> 
> This PR introduces `skiac_picture_recorder_destroy` in the C++ FFI layer and wires it into Rust (`src/sk.rs`) via a new `Drop` impl so `SkPictureRecorder` allocations are automatically `delete`d when the wrapper is dropped.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 427f59a4b28e0cb37c3f2861a8b38b06b6c6be62. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->