### PR TITLE
fix: prevent memory leaks in encode_stream callback and SkPixmap

### DIFF
--- a/skia-c/skia_c.cpp
+++ b/skia-c/skia_c.cpp
@@ -293,8 +293,8 @@ bool skiac_surface_encode_stream(skiac_surface* c_surface,
                                  int quality,
                                  write_callback_t write_callback,
                                  void* context) {
-  auto sk_pixmap = new SkPixmap();
-  if (!SURFACE_CAST->peekPixels(sk_pixmap)) {
+  SkPixmap sk_pixmap;
+  if (!SURFACE_CAST->peekPixels(&sk_pixmap)) {
     return false;
   }
   SkJavaScriptWStream stream(write_callback, context);
@@ -302,19 +302,19 @@ bool skiac_surface_encode_stream(skiac_surface* c_surface,
   if (format == int(SkEncodedImageFormat::kJPEG)) {
     SkJpegEncoder::Options options;
     options.fQuality = quality;
-    encoder = SkJpegEncoder::Make(&stream, *sk_pixmap, options);
+    encoder = SkJpegEncoder::Make(&stream, sk_pixmap, options);
   } else if (format == int(SkEncodedImageFormat::kPNG)) {
-    encoder = SkPngEncoder::Make(&stream, *sk_pixmap, SkPngEncoder::Options());
+    encoder = SkPngEncoder::Make(&stream, sk_pixmap, SkPngEncoder::Options());
   } else if (format == int(SkEncodedImageFormat::kWEBP)) {
     SkWebpEncoder::Options options;
     options.fCompression = quality == 100
                                ? SkWebpEncoder::Compression::kLossless
                                : SkWebpEncoder::Compression::kLossy;
     options.fQuality = quality == 100 ? 75 : quality;
-    return SkWebpEncoder::Encode(&stream, *sk_pixmap, options);
+    return SkWebpEncoder::Encode(&stream, sk_pixmap, options);
   }
   if (encoder) {
-    return encoder->encodeRows(sk_pixmap->height());
+    return encoder->encodeRows(sk_pixmap.height());
   }
   return false;
 }


### PR DESCRIPTION
Fix two memory leaks in the image encoding path:

1. Rust callback leak: encode_image_stream_callback used
   Box::leak(Box::from_raw(...)) which permanently leaked the callback
   allocation on every invocation. The callback is now borrowed via a
   raw pointer dereference, and the Box is freed by encode_image_inner
   after the synchronous encode_stream call returns.

2. C++ SkPixmap leak: skiac_surface_encode_stream heap-allocated a
   SkPixmap with `new` but never deleted it in any code path. Replaced
   with a stack-allocated SkPixmap since it is only used within the
   function scope.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is unchanged but touches Rust/C++ FFI memory ownership in the synchronous `encode_stream` path; risk is limited to potential callback lifetime or pointer misuse if the sync assumption ever changes.
> 
> **Overview**
> Fixes two memory leaks in the image stream encoding path.
> 
> On the C++ side, `skiac_surface_encode_stream` now uses a stack-allocated `SkPixmap` and passes it by reference (removing the previous `new SkPixmap()` allocation that was never freed).
> 
> On the Rust side, `encode_image_inner` now owns and explicitly frees the boxed callback after the synchronous `encode_stream` call completes, while `encode_image_stream_callback` borrows the callback from the raw context pointer instead of taking ownership/leaking it across invocations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f636b8fd75127b2ed2b97b7ff8a67a79abd039d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->