### PR TITLE
fix: snapshot pixel data in putImageData for deferred rendering mode

### DIFF
--- a/skia-c/skia_c.hpp
+++ b/skia-c/skia_c.hpp
@@ -909,7 +909,8 @@ void skiac_canvas_put_image_data(skiac_canvas* c_canvas,
                                  float dirty_y,
                                  float dirty_width,
                                  float dirty_height,
-                                 uint8_t cs);
+                                 uint8_t cs,
+                                 bool snapshot);
 void skiac_canvas_draw_picture(skiac_canvas* c_canvas,
                                skiac_picture* c_picture,
                                skiac_matrix* c_matrix,

--- a/src/sk.rs
+++ b/src/sk.rs
@@ -620,6 +620,7 @@ pub mod ffi {
       dirty_width: f32,
       dirty_height: f32,
       color_space: u8,
+      snapshot: bool,
     );
 
     pub fn skiac_canvas_draw_picture(
@@ -2818,6 +2819,8 @@ impl Canvas {
   /// drawImageRect with kSrc blend mode for putImageData.
   /// Replaces destination pixels per HTML spec.
   /// Works on recording canvases (PictureRecorder).
+  /// When `snapshot` is true, the pixel data is copied so the resulting SkImage
+  /// is independent of the source buffer (required for deferred/recorded mode).
   pub fn put_image_data(
     &mut self,
     image: &ImageData,
@@ -2828,6 +2831,7 @@ impl Canvas {
     dirty_width: f32,
     dirty_height: f32,
     color_space: ColorSpace,
+    snapshot: bool,
   ) {
     unsafe {
       ffi::skiac_canvas_put_image_data(
@@ -2844,6 +2848,7 @@ impl Canvas {
         dirty_width,
         dirty_height,
         color_space as u8,
+        snapshot,
       )
     }
   }


### PR DESCRIPTION
When the same ImageData object is reused across multiple putImageData()
calls (as pdfjs-dist does for chunked rendering), the deferred rendering
path captured a reference to the underlying JS buffer rather than copying
it. This caused all recorded SkPictures to alias the same buffer, so only
the last chunk's data was rendered.

Apply a COW strategy: only copy pixel data in deferred mode (where the
SkPicture must outlive the call) via RasterFromPixmapCopy, while keeping
the zero-copy RasterFromPixmap path for direct mode where drawImageRect
consumes pixels immediately.

Closes #1212

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the `putImageData` rendering path and Skia FFI boundary; incorrect snapshotting could cause memory/perf regressions or subtle rendering differences, but the change is narrowly scoped and covered by a new regression test.
> 
> **Overview**
> Fixes deferred/recorded `putImageData` so reusing the same `ImageData` buffer across calls no longer corrupts previously recorded chunks.
> 
> Adds a `snapshot` flag through the Rust→C++ Skia FFI and, when recording, switches to `SkImages::RasterFromPixmapCopy` to copy pixel data; direct rendering paths continue using the zero-copy `RasterFromPixmap` behavior.
> 
> Introduces a regression test reproducing pdf.js-style chunked rendering with a reused `ImageData` to ensure earlier chunks remain correct.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3b8a4c6e50c8ef53cc3cf9123ff6cd3c05e292c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->