### PR TITLE
fix: prevent memory leak when drawing canvas onto another via drawImage()

### DIFF
--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -130,9 +130,16 @@ impl Context {
   /// Flush deferred rendering to surface (if deferred mode is enabled)
   pub fn flush(&mut self) {
     if let Some(ref recorder) = self.page_recorder {
-      recorder.borrow_mut().playback_to(&mut self.surface.canvas);
-      // DON'T reset here - preserve layers for incremental rendering
-      // Reset only happens on canvas resize or explicit clear
+      let mut rec = recorder.borrow_mut();
+      rec.playback_to(&mut self.surface.canvas);
+      // Consolidate accumulated layers into a single snapshot-based picture
+      // to prevent unbounded memory growth when canvas is repeatedly drawn
+      // via drawImage() (see: https://github.com/Brooooooklyn/canvas/issues/1221)
+      if rec.should_consolidate()
+        && let Some(snapshot) = self.surface.make_image_snapshot()
+      {
+        rec.consolidate_with_snapshot(snapshot);
+      }
     }
   }
 

--- a/src/page_recorder.rs
+++ b/src/page_recorder.rs
@@ -1,5 +1,7 @@
 use crate::picture_recorder::PictureRecorder;
-use crate::sk::{Canvas, ColorSpace, Matrix, Path as SkPath, SkPicture, Surface};
+use crate::sk::{
+  Canvas, ColorSpace, FilterQuality, Matrix, Path as SkPath, SkImage, SkPicture, Surface,
+};
 
 /// Persistent surface for caching intermediate rendering results.
 /// Based on skia-canvas's RecordingSurface pattern.
@@ -222,6 +224,32 @@ impl PageRecorder {
         layer.playback(target);
       }
       self.depth = self.layers.len(); // Update depth to mark all layers as rendered
+    }
+  }
+
+  /// Returns whether layers should be consolidated to prevent memory buildup
+  pub fn should_consolidate(&self) -> bool {
+    self.layers.len() > 1
+  }
+
+  /// Replace all accumulated layers with a single picture that draws the given
+  /// surface snapshot. This bounds memory to O(canvas_size) instead of
+  /// O(total_draw_commands), preventing unbounded growth when a canvas is
+  /// repeatedly drawn via drawImage().
+  pub fn consolidate_with_snapshot(&mut self, image: SkImage) {
+    let mut compositor = PictureRecorder::new();
+    compositor.begin_recording(0.0, 0.0, self.width, self.height);
+    let Some(canvas) = compositor.get_recording_canvas() else {
+      return;
+    };
+    image.draw(canvas, 0.0, 0.0, FilterQuality::Low);
+    if let Some(picture) = compositor.finish_recording_as_picture() {
+      self.layers.clear();
+      self.layers.push(picture);
+      self.depth = 1;
+      self.cached_picture = None;
+      self.layers_at_cache = 0;
+      self.recording_surface.reset();
     }
   }
 


### PR DESCRIPTION
PageRecorder layers accumulated unboundedly when drawImage(canvas) was
called repeatedly (e.g., in a game render loop). Each call promoted a
new SkPicture layer that was never freed, causing memory to grow to
10-17 GB over many frames.

After flush() renders all deferred layers to the surface, consolidate
them into a single snapshot-based picture. This bounds memory to
O(canvas_size) instead of O(total_draw_commands).

Closes https://github.com/Brooooooklyn/canvas/issues/1221

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core deferred rendering/flush behavior and layer caching; mistakes could cause visual regressions or lost incremental rendering state, but the change is localized and guarded behind snapshot success.
> 
> **Overview**
> Prevents unbounded memory growth in deferred rendering when a canvas is repeatedly drawn onto another via `drawImage()`.
> 
> After `Context::flush()` replays pending `PageRecorder` layers to the backing surface, it now snapshots the surface and consolidates accumulated layers into a single snapshot-backed `SkPicture`. `PageRecorder` gains `should_consolidate()` and `consolidate_with_snapshot()` to replace prior layers, reset caches, and bound memory to the canvas size.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95d62765fc400c8e1f71a34e3078e08af878c88b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->