### PR TITLE
fix(image): loadImage settles on invalid input

### DIFF
--- a/__test__/loadimage.spec.ts
+++ b/__test__/loadimage.spec.ts
@@ -86,3 +86,37 @@ test('should load file url', async (t) => {
   t.is(img.width, 512)
   t.is(img.height, 512)
 })
+
+// Regression tests for https://github.com/Brooooooklyn/canvas/issues/1255
+// loadImage must settle (resolve or reject) for invalid inputs — must not hang.
+
+const TIMEOUT_SENTINEL = Symbol('loadImage timed out')
+
+async function settles<T>(promise: Promise<T>, ms = 2000): Promise<T | typeof TIMEOUT_SENTINEL> {
+  let timer: NodeJS.Timeout | undefined
+  try {
+    return await Promise.race<T | typeof TIMEOUT_SENTINEL>([
+      promise,
+      new Promise<typeof TIMEOUT_SENTINEL>((resolve) => {
+        timer = setTimeout(() => resolve(TIMEOUT_SENTINEL), ms)
+      }),
+    ])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}
+
+test('loadImage settles on empty Buffer (issue #1255)', async (t) => {
+  const result = await settles(loadImage(Buffer.alloc(0)).catch((e) => e))
+  t.not(result, TIMEOUT_SENTINEL, 'loadImage(Buffer.alloc(0)) hung')
+})
+
+test('loadImage settles on tiny invalid Buffer (issue #1255)', async (t) => {
+  const result = await settles(loadImage(Buffer.from([1])).catch((e) => e))
+  t.not(result, TIMEOUT_SENTINEL, 'loadImage(Buffer.from([1])) hung')
+})
+
+test('loadImage settles on invalid base64 data URL (issue #1255)', async (t) => {
+  const result = await settles(loadImage('data:image/png;base64,=').catch((e) => e))
+  t.not(result, TIMEOUT_SENTINEL, 'loadImage("data:image/png;base64,=") hung')
+})

--- a/load-image.js
+++ b/load-image.js
@@ -31,6 +31,10 @@ module.exports = async function loadImage(source, options = {}) {
     const commaIdx = source.indexOf(',')
     const encoding = source.lastIndexOf('base64', commaIdx) < 0 ? 'utf-8' : 'base64'
     const data = Buffer.from(source.slice(commaIdx + 1), encoding)
+    // Empty payload would silently complete on Image (HTML spec) and the loadImage
+    // promise would never settle; reject upfront instead.
+    // See https://github.com/Brooooooklyn/canvas/issues/1255
+    if (data.length === 0) throw new Error(`Invalid data URI: empty payload in ${source.slice(0, 64)}`)
     return createImage(data, options.alt)
   }
   // if source is a string or URL instance
@@ -118,6 +122,13 @@ function consumeStream(res) {
 }
 
 async function createImage(src, alt) {
+  // Empty Buffer / Uint8Array: Image follows the HTML spec (silent completion,
+  // no events) so the promise below would hang. Reject upfront.
+  // See https://github.com/Brooooooklyn/canvas/issues/1255
+  if ((Buffer.isBuffer(src) || src instanceof Uint8Array) && src.length === 0) {
+    throw new Error('loadImage: empty image data')
+  }
+
   const image = new Image()
   if (typeof alt === 'string') image.alt = alt
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -352,14 +352,17 @@ impl Image {
     // This must happen for BOTH empty and valid src to prevent race conditions
     self.load_generation = self.load_generation.wrapping_add(1);
 
-    // Check if src is empty (per HTML spec)
-    // Also treat very small buffers as empty to avoid invalid/ambiguous image headers.
-    let is_empty_or_too_small = match &data {
-      Either::A(buffer) => buffer.is_empty() || buffer.len() < 5,
+    // Check if src is empty per HTML spec.
+    // The previous `< 5` byte heuristic incorrectly silenced tiny invalid buffers
+    // (e.g. Buffer.from([1])), causing loadImage() to hang. Such buffers must
+    // fall through to the async decoder, which reports them via onerror.
+    // See https://github.com/Brooooooklyn/canvas/issues/1255
+    let is_empty = match &data {
+      Either::A(buffer) => buffer.is_empty(),
       Either::B(string) => string.is_empty(),
     };
 
-    if is_empty_or_too_small {
+    if is_empty {
       // HTML spec: empty src = clear state, complete=true, NO events
       self.src = None;
       self.current_src = None;
@@ -1174,7 +1177,24 @@ impl<'env> ScopedTask<'env> for BitmapDecoder {
           self_mut.accounted_bytes = new_bytes;
         }
       }
-      DecodeStatus::Empty => {}
+      DecodeStatus::Empty => {
+        // ERROR PATH: empty / undecodable input. Surface via onerror so callers
+        // (especially loadImage) settle instead of hanging.
+        // See https://github.com/Brooooooklyn/canvas/issues/1255
+        self_mut.width = -1.0;
+        self_mut.height = -1.0;
+        self_mut.natural_width = 0.0;
+        self_mut.natural_height = 0.0;
+        self_mut.file_content = None;
+        self_mut._avif_image_ref = None;
+        self_mut.is_svg = false;
+        self_mut.need_regenerate_bitmap = false;
+        if self_mut.accounted_bytes != 0 {
+          env.adjust_external_memory(-self_mut.accounted_bytes)?;
+          self_mut.accounted_bytes = 0;
+        }
+        err = Some("Empty image data");
+      }
       DecodeStatus::InvalidSvg => {
         // ERROR PATH: clear state like reject() does
         // Reset width/height to auto (-1.0) so getters return 0 (from natural_width/height)


### PR DESCRIPTION
The `< 5` byte short-circuit added in v0.1.87 silenced tiny invalid buffers, and the `DecodeStatus::Empty` arm fired no events, so loadImage() promises hung forever on `Buffer.from([1])`, `'data:image/png;base64,='`, etc. Drop the heuristic, surface Empty via onerror, and reject empty Buffer/data-URI inputs in loadImage() upfront so the HTML-spec silent-completion path never strands callers.

Close https://github.com/Brooooooklyn/canvas/issues/1255

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core image loading/decoding paths in both JS and the Rust `Image` implementation; behavioral changes to error vs silent-complete could affect callers relying on previous edge-case behavior.
> 
> **Overview**
> Fixes a regression where `loadImage()` could hang forever on invalid inputs (e.g. empty buffers, tiny garbage buffers, and empty/invalid `data:` URIs).
> 
> `load-image.js` now rejects upfront for empty `Buffer`/`Uint8Array` sources and `data:` URIs with empty payloads, while `src/image.rs` removes the `< 5 bytes` “treat as empty” heuristic and makes `DecodeStatus::Empty` propagate through `onerror`/promise rejection so invalid data reliably settles.
> 
> Adds regression tests in `__test__/loadimage.spec.ts` that enforce `loadImage()` resolves or rejects within a timeout for these invalid cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d71b35f3573ec1d7bddeefcd76ff193586edf0ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->