### PR TITLE
chore: rebrand @napi-rs/canvas → @aphrody-code/canvas + GH Packages publish

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -29,11 +29,10 @@ jobs:
         with:
           submodules: true
 
-      - name: Setup node
-        uses: actions/setup-node@v6
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
         with:
-          node-version: 24
-          cache: 'yarn'
+          bun-version: latest
 
       - name: Install
         uses: ./.github/actions/setup-rust
@@ -42,7 +41,7 @@ jobs:
           components: clippy, rustfmt
 
       - name: Install dependencies
-        run: yarn install --immutable --mode=skip-build
+        run: bun install --immutable --mode=skip-build
 
       - name: Download skia binary
         run: |
@@ -50,7 +49,7 @@ jobs:
           node ./scripts/release-skia-binary.mjs --download
 
       - name: 'Lint JS/TS'
-        run: yarn lint
+        run: bun lint
 
       - name: Cargo fmt
         run: cargo fmt -- --check
@@ -80,18 +79,18 @@ jobs:
             build: |
               rustc --print target-cpus
               clang --version
-              yarn build --target x86_64-apple-darwin
+              bun run build --target x86_64-apple-darwin
             downloadTarget: ''
           - host: windows-latest
             setup: |
               choco upgrade llvm
-            build: yarn build --target x86_64-pc-windows-msvc
+            build: bun run build --target x86_64-pc-windows-msvc
             target: 'x86_64-pc-windows-msvc'
             downloadTarget: ''
           - host: windows-latest
             setup: |
               choco upgrade llvm
-            build: yarn build --target aarch64-pc-windows-msvc
+            build: bun run build --target aarch64-pc-windows-msvc
             target: 'aarch64-pc-windows-msvc'
             downloadTarget: 'aarch64-pc-windows-msvc'
           - host: ubuntu-latest
@@ -101,18 +100,18 @@ jobs:
             build: >-
               rustup install &&
               rustup target add x86_64-unknown-linux-gnu &&
-              yarn build --target x86_64-unknown-linux-gnu
+              bun run build --target x86_64-unknown-linux-gnu
           - host: ubuntu-latest
             downloadTarget: 'x86_64-unknown-linux-musl'
             target: 'x86_64-unknown-linux-musl'
-            build: yarn build --target x86_64-unknown-linux-musl -x
+            build: bun run build --target x86_64-unknown-linux-musl -x
           - host: macos-latest
             downloadTarget: 'aarch64-apple-darwin'
             target: 'aarch64-apple-darwin'
             build: |
               export MACOSX_DEPLOYMENT_TARGET='11.0'
               clang --version
-              yarn build --target aarch64-apple-darwin
+              bun run build --target aarch64-apple-darwin
           - host: ubuntu-latest
             downloadTarget: 'aarch64-unknown-linux-gnu'
             target: 'aarch64-unknown-linux-gnu'
@@ -121,11 +120,11 @@ jobs:
               set -e &&
               rustup install &&
               rustup target add aarch64-unknown-linux-gnu &&
-              yarn build --target aarch64-unknown-linux-gnu
+              bun run build --target aarch64-unknown-linux-gnu
           - host: ubuntu-24.04-arm
             target: 'aarch64-unknown-linux-musl'
             downloadTarget: 'aarch64-unknown-linux-musl'
-            build: yarn build --target aarch64-unknown-linux-musl -x
+            build: bun run build --target aarch64-unknown-linux-musl -x
           - host: ubuntu-latest
             target: 'aarch64-linux-android'
             downloadTarget: 'aarch64-linux-android'
@@ -138,7 +137,7 @@ jobs:
               export CC=aarch64-linux-android24-clang
               export CXX=aarch64-linux-android24-clang++
               export CMAKE_TOOLCHAIN_FILE_aarch64_linux_android="$(pwd)/cmake/android-determine.cmake"
-              yarn build --target aarch64-linux-android
+              bun run build --target aarch64-linux-android
           - host: ubuntu-latest
             target: 'riscv64gc-unknown-linux-gnu'
             downloadTarget: 'riscv64gc-unknown-linux-gnu'
@@ -147,7 +146,7 @@ jobs:
               sudo apt-get install gcc-riscv64-linux-gnu g++-riscv64-linux-gnu -y
               export CC=riscv64-linux-gnu-gcc
               export CXX=riscv64-linux-gnu-g++
-              yarn build --target riscv64gc-unknown-linux-gnu
+              bun run build --target riscv64gc-unknown-linux-gnu
 
     name: stable - ${{ matrix.settings.target }} - node@24
     runs-on: ${{ matrix.settings.host }}
@@ -157,11 +156,10 @@ jobs:
         with:
           submodules: true
 
-      - name: Setup node
-        uses: actions/setup-node@v6
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
         with:
-          node-version: 24
-          cache: 'yarn'
+          bun-version: latest
 
       - name: Set env
         if: matrix.settings.host == 'windows-latest'
@@ -190,7 +188,7 @@ jobs:
           targets: ${{ matrix.settings.target }}
 
       - name: Install dependencies
-        run: yarn install --immutable --mode=skip-build
+        run: bun install --immutable --mode=skip-build
 
       - name: Setup toolchain
         run: ${{ matrix.settings.setup }}
@@ -237,9 +235,8 @@ jobs:
             apt-get install -y clang-19
             ln -s /usr/bin/clang-19 /usr/bin/clang
             ln -s /usr/bin/clang++-19 /usr/bin/clang++
-            curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
-            apt-get install -y nodejs
-            npm install -g yarn corepack
+            curl -fsSL https://bun.sh/install | bash
+            ln -s /root/.bun/bin/bun /usr/local/bin/bun
       - uses: actions/checkout@v6
         with:
           submodules: true
@@ -249,10 +246,10 @@ jobs:
         with:
           cmake-version: '3.x'
 
-      - name: Setup node
-        uses: actions/setup-node@v6
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
         with:
-          node-version: 24
+          bun-version: latest
 
       - name: Install
         uses: ./.github/actions/setup-rust
@@ -260,9 +257,7 @@ jobs:
           targets: 'armv7-unknown-linux-gnueabihf'
 
       - name: Install dependencies
-        run: |
-          corepack enable
-          yarn install --immutable --mode=skip-build
+        run: bun install --immutable --mode=skip-build
 
       - name: Download skia binary
         run: |
@@ -273,7 +268,7 @@ jobs:
       - name: Build
         run: |
           export CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc
-          yarn build --target armv7-unknown-linux-gnueabihf
+          bun run build --target armv7-unknown-linux-gnueabihf
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7
@@ -312,24 +307,22 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           out-file-path: __test__/fonts/
 
-      - name: Setup node
-        uses: actions/setup-node@v6
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
         if: startsWith(matrix.settings.target, 'x86_64')
         with:
-          node-version: ${{ matrix.node }}
-          cache: 'yarn'
+          bun-version: latest
           architecture: 'x64'
 
-      - name: Setup node
-        uses: actions/setup-node@v6
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
         if: startsWith(matrix.settings.target, 'aarch64')
         with:
-          node-version: ${{ matrix.node }}
-          cache: 'yarn'
+          bun-version: latest
           architecture: 'arm64'
 
       - name: Install dependencies
-        run: yarn install --immutable
+        run: bun install --immutable
 
       - name: Download artifacts
         uses: actions/download-artifact@v8
@@ -342,7 +335,7 @@ jobs:
         run: node ./scripts/release-skia-binary.mjs --download-icu
 
       - name: Test bindings
-        run: yarn test:ci
+        run: bun test:ci
         env:
           RUN_STRESS_TESTS: 'true'
 
@@ -377,15 +370,14 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           out-file-path: __test__/fonts/
 
-      - name: Setup node
-        uses: actions/setup-node@v6
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
         with:
-          node-version: ${{ matrix.node }}
-          cache: 'yarn'
+          bun-version: latest
           architecture: 'arm64'
 
       - name: Install dependencies
-        run: yarn install --immutable --mode=skip-build
+        run: bun install --immutable --mode=skip-build
 
       - name: Download artifacts
         uses: actions/download-artifact@v8
@@ -397,7 +389,7 @@ jobs:
         run: node ./scripts/release-skia-binary.mjs --download-icu
 
       - name: Test bindings
-        run: yarn test:ci
+        run: bun test:ci
 
       - name: Test failed
         if: ${{ failure() }}
@@ -428,14 +420,13 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           out-file-path: __test__/fonts/
 
-      - name: Setup node
-        uses: actions/setup-node@v6
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
         with:
-          node-version: ${{ matrix.node }}
-          cache: 'yarn'
+          bun-version: latest
 
       - name: Install dependencies
-        run: yarn install --immutable --mode=skip-build
+        run: bun install --immutable --mode=skip-build
 
       - name: Download artifacts
         uses: actions/download-artifact@v8
@@ -448,7 +439,7 @@ jobs:
         shell: bash
 
       - name: Test bindings
-        run: docker run --rm -v $(pwd):/canvas -w /canvas node:${{ matrix.node }}-slim yarn test:ci
+        run: docker run --rm -v $(pwd):/canvas -w /canvas oven/bun:latest bun run test:ci
 
       - name: Test failed
         if: ${{ failure() }}
@@ -479,16 +470,13 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           out-file-path: __test__/fonts/
 
-      - name: Setup node
-        uses: actions/setup-node@v6
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
         with:
-          node-version: ${{ matrix.node }}
-          cache: 'yarn'
+          bun-version: latest
 
       - name: Install dependencies
-        run: |
-          yarn config set supportedArchitectures.libc "musl"
-          yarn install --immutable --mode=skip-build
+        run: bun install --immutable --mode=skip-build
 
       - name: Download artifacts
         uses: actions/download-artifact@v8
@@ -501,7 +489,7 @@ jobs:
         shell: bash
 
       - name: Test bindings
-        run: docker run --rm -v $(pwd):/canvas -w /canvas node:${{ matrix.node }}-alpine yarn test:ci
+        run: docker run --rm -v $(pwd):/canvas -w /canvas oven/bun:alpine bun run test:ci
 
       - name: Test failed
         if: ${{ failure() }}
@@ -543,16 +531,16 @@ jobs:
         shell: bash
 
       - name: Install dependencies
-        run: yarn install --immutable --mode=skip-build
+        run: bun install --immutable --mode=skip-build
 
       - name: Setup and run tests
         uses: tj-actions/docker-run@v2
         with:
-          image: node:${{ matrix.node }}-slim
+          image: oven/bun:latest
           name: test-aarch64-${{ matrix.node }}
           options: '--platform linux/arm64 -v ${{ github.workspace }}:/skia -w /skia'
           args: |
-            sh -c "set -e && yarn test:ci && ls -la"
+            sh -c "set -e && bun run test:ci && ls -la"
 
       - name: Test failed
         if: ${{ failure() }}
@@ -591,19 +579,16 @@ jobs:
         shell: bash
 
       - name: Install dependencies
-        run: |
-          yarn config set supportedArchitectures.cpu "arm64"
-          yarn config set supportedArchitectures.libc "musl"
-          yarn install --immutable --mode=skip-build
+        run: bun install --immutable --mode=skip-build
 
       - name: Setup and run tests
         uses: tj-actions/docker-run@v2
         with:
-          image: node:lts-alpine
+          image: oven/bun:alpine
           name: test-alpine-musl
           options: '--platform linux/arm64 -v ${{ github.workspace }}:/skia -w /skia'
           args: |
-            sh -c "set -e && yarn test:ci"
+            sh -c "set -e && bun run test:ci"
 
       - name: Test failed
         if: ${{ failure() }}
@@ -627,7 +612,7 @@ jobs:
           targets: aarch64-apple-darwin
 
       - name: Install dependencies
-        run: yarn install --immutable --mode=skip-build
+        run: bun install --immutable --mode=skip-build
 
       - name: Install llvm
         run: brew install llvm
@@ -651,11 +636,10 @@ jobs:
         with:
           submodules: true
 
-      - name: Setup node
-        uses: actions/setup-node@v6
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
         with:
-          node-version: 24
-          cache: 'yarn'
+          bun-version: latest
 
       - name: Install
         uses: ./.github/actions/setup-rust
@@ -663,7 +647,7 @@ jobs:
           targets: x86_64-unknown-linux-gnu
 
       - name: Install dependencies
-        run: yarn install --immutable
+        run: bun install --immutable
 
       - name: Download skia binary
         run: |
@@ -671,10 +655,10 @@ jobs:
           node ./scripts/release-skia-binary.mjs --download
 
       - name: 'Build'
-        run: yarn build
+        run: bun run build
 
       - name: 'Run benchmark'
-        run: yarn bench
+        run: bun run bench
 
   publish:
     name: Publish
@@ -696,14 +680,13 @@ jobs:
         with:
           submodules: true
 
-      - name: Setup node
-        uses: actions/setup-node@v6
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
         with:
-          node-version: 24
-          cache: 'yarn'
+          bun-version: latest
 
       - name: Install dependencies
-        run: yarn install --immutable --mode=skip-build
+        run: bun install --immutable --mode=skip-build
 
       - name: Download all artifacts
         uses: actions/download-artifact@v8
@@ -711,7 +694,7 @@ jobs:
           path: artifacts
 
       - name: Move artifacts
-        run: yarn artifacts
+        run: bun run artifacts
 
       - name: Download ICU for Windows
         run: node ./scripts/release-skia-binary.mjs --download-icu
@@ -722,13 +705,12 @@ jobs:
 
       - name: Publish
         run: |
-          npm install -g npm
           if git log -1 --pretty=%B | grep "^[0-9]\+\.[0-9]\+\.[0-9]\+$";
           then
-            npm publish --access public
+            bun publish --access public
           elif git log -1 --pretty=%B | grep "^[0-9]\+\.[0-9]\+\.[0-9]\+";
           then
-            npm publish --tag next --access public
+            bun publish --tag next --access public
           else
             echo "Not a release, skipping publish"
           fi

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -703,16 +703,32 @@ jobs:
         run: ls -R ./npm
         shell: bash
 
+      - name: Setup GitHub Packages auth
+        run: |
+          # Le `bun publish` lit `.npmrc` pour résoudre l'auth du registry GH Packages.
+          # Le scope @aphrody-code est routé vers npm.pkg.github.com, le token vient
+          # du GITHUB_TOKEN auto-fourni par Actions (avec permission packages: write).
+          cat > .npmrc <<EOF
+          @aphrody-code:registry=https://npm.pkg.github.com/
+          //npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}
+          always-auth=true
+          EOF
+          # Idem dans chaque sub-package npm/<target>/ pour `napi prepublish`
+          for d in npm/*/; do cp .npmrc "$d/.npmrc"; done
+
       - name: Publish
         run: |
-          if git log -1 --pretty=%B | grep "^[0-9]\+\.[0-9]\+\.[0-9]\+$";
+          # Détecte un tag de release "X.Y.Z" ou "X.Y.Z-prerelease" dans le dernier commit
+          if git log -1 --pretty=%B | grep -qE "^[0-9]+\.[0-9]+\.[0-9]+(-[a-z0-9.]+)?$";
           then
+            # Le `prepublishOnly` (`napi prepublish -t npm`) recopie le binaire
+            # téléchargé depuis les artifacts dans chaque npm/<target>/, puis
+            # `bun publish` itère sur eux + le main package.
             bun publish --access public
-          elif git log -1 --pretty=%B | grep "^[0-9]\+\.[0-9]\+\.[0-9]\+";
-          then
-            bun publish --tag next --access public
           else
-            echo "Not a release, skipping publish"
+            echo "Not a release commit, skipping publish"
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Permet à `bun publish` de re-authentifier au besoin
+          NPM_CONFIG_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/skia.yaml
+++ b/.github/workflows/skia.yaml
@@ -36,11 +36,10 @@ jobs:
         run: ls -R "C:\Program Files\LLVM"
         shell: bash
 
-      - name: Setup node
-        uses: actions/setup-node@v6
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
         with:
-          node-version: 24
-          cache: 'yarn'
+          bun-version: latest
 
       - uses: actions/setup-python@v6
         with:
@@ -103,7 +102,7 @@ jobs:
         run: node ./scripts/build-skia.js
 
       - name: Install dependencies
-        run: yarn install --immutable --mode=skip-build
+        run: bun install --immutable --mode=skip-build
 
       - name: Upload release
         run: node ./scripts/release-skia-binary.mjs --upload
@@ -126,11 +125,10 @@ jobs:
         run: ls -R "C:\Program Files\LLVM"
         shell: bash
 
-      - name: Setup node
-        uses: actions/setup-node@v6
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
         with:
-          node-version: 24
-          cache: 'yarn'
+          bun-version: latest
 
       - uses: actions/setup-python@v6
         with:
@@ -158,7 +156,7 @@ jobs:
         run: node ./scripts/build-skia.js --target=aarch64-pc-windows-msvc
 
       - name: Install dependencies
-        run: yarn install --immutable --mode=skip-build
+        run: bun install --immutable --mode=skip-build
 
       - name: Upload release
         run: node ./scripts/release-skia-binary.mjs --upload --target=aarch64-pc-windows-msvc
@@ -177,11 +175,10 @@ jobs:
         with:
           submodules: true
 
-      - name: Setup node
-        uses: actions/setup-node@v6
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
         with:
-          node-version: 24
-          cache: 'yarn'
+          bun-version: latest
 
       - uses: actions/setup-python@v6
         with:
@@ -203,7 +200,7 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: '11.0'
 
       - name: Install dependencies
-        run: yarn install --immutable --mode=skip-build
+        run: bun install --immutable --mode=skip-build
 
       - name: Upload release
         run: node ./scripts/release-skia-binary.mjs --upload --target=aarch64-apple-darwin
@@ -221,11 +218,10 @@ jobs:
         with:
           submodules: true
 
-      - name: Setup node
-        uses: actions/setup-node@v6
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
         with:
-          node-version: 24
-          cache: 'yarn'
+          bun-version: latest
 
       - uses: mlugg/setup-zig@v2
         with:
@@ -241,7 +237,7 @@ jobs:
         run: node ./scripts/build-skia.js --target=x86_64-unknown-linux-musl
 
       - name: Install dependencies
-        run: yarn install --immutable --mode=skip-build
+        run: bun install --immutable --mode=skip-build
 
       - name: Upload release
         run: node ./scripts/release-skia-binary.mjs --upload --target=x86_64-unknown-linux-musl
@@ -258,11 +254,10 @@ jobs:
         with:
           submodules: true
 
-      - name: Setup node
-        uses: actions/setup-node@v6
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
         with:
-          node-version: 24
-          cache: 'yarn'
+          bun-version: latest
 
       - uses: actions/setup-python@v6
         with:
@@ -287,7 +282,7 @@ jobs:
           docker run --user "$(id -u):$(id -g)" -e SKIP_SYNC_SK_DEPS=0 --rm -v $(pwd):/canvas -w /canvas builder node ./scripts/build-skia.js --target=aarch64-unknown-linux-gnu
 
       - name: Install dependencies
-        run: yarn install --immutable --mode=skip-build
+        run: bun install --immutable --mode=skip-build
 
       - name: Upload release
         run: node ./scripts/release-skia-binary.mjs --upload --target=aarch64-unknown-linux-gnu
@@ -305,11 +300,10 @@ jobs:
         with:
           submodules: true
 
-      - name: Setup node
-        uses: actions/setup-node@v6
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
         with:
-          node-version: 24
-          cache: 'yarn'
+          bun-version: latest
 
       - uses: mlugg/setup-zig@v2
         with:
@@ -325,7 +319,7 @@ jobs:
         run: node ./scripts/build-skia.js --target=aarch64-unknown-linux-musl
 
       - name: Install dependencies
-        run: yarn install --immutable --mode=skip-build
+        run: bun install --immutable --mode=skip-build
 
       - name: Upload release
         run: node ./scripts/release-skia-binary.mjs --upload --target=aarch64-unknown-linux-musl
@@ -345,18 +339,17 @@ jobs:
         run: |
           apt-get update
           apt-get install -y gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf libatomic1-armhf-cross git build-essential cmake ninja-build wget curl python3
-          curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
-          apt-get install -y nodejs
-          npm install -g yarn corepack
+          curl -fsSL https://bun.sh/install | bash
+          ln -s /root/.bun/bin/bun /usr/local/bin/bun
           ln -s /usr/bin/python3 /usr/bin/python
       - uses: actions/checkout@v6
         with:
           submodules: true
 
-      - name: Setup node
-        uses: actions/setup-node@v6
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
         with:
-          node-version: 24
+          bun-version: latest
 
       - name: Sync deps
         uses: nick-fields/retry@v4
@@ -375,9 +368,7 @@ jobs:
           SKIP_SYNC_SK_DEPS: 0
 
       - name: Install dependencies
-        run: |
-          corepack enable
-          yarn install --immutable --mode=skip-build
+        run: bun install --immutable --mode=skip-build
 
       - name: Upload release
         run: |
@@ -398,11 +389,10 @@ jobs:
         with:
           submodules: true
 
-      - name: Setup node
-        uses: actions/setup-node@v6
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
         with:
-          node-version: 24
-          cache: 'yarn'
+          bun-version: latest
 
       - uses: actions/setup-python@v6
         with:
@@ -422,7 +412,7 @@ jobs:
         run: node ./scripts/build-skia.js --target=aarch64-linux-android
 
       - name: Install dependencies
-        run: yarn install --immutable --mode=skip-build
+        run: bun install --immutable --mode=skip-build
 
       - name: Upload release
         run: node ./scripts/release-skia-binary.mjs --upload --target=aarch64-linux-android
@@ -437,11 +427,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
-      - name: Setup node
-        uses: actions/setup-node@v6
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
         with:
-          node-version: 24
-          cache: 'yarn'
+          bun-version: latest
       - uses: actions/setup-python@v6
         with:
           python-version: '3.x'
@@ -459,7 +448,7 @@ jobs:
           CC: riscv64-linux-gnu-gcc
           CXX: riscv64-linux-gnu-g++
       - name: Install dependencies
-        run: yarn install --immutable --mode=skip-build
+        run: bun install --immutable --mode=skip-build
 
       - name: Upload release
         run: node ./scripts/release-skia-binary.mjs --upload --target=riscv64gc-unknown-linux-gnu

--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,4 @@ llvm-project-llvmorg-*
 *.code-workspace
 /example/output.mp4
 /example/lottie_extracted
+.npmrc

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn lint-staged
+bun run lint-staged

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,6 @@ RUN apt-get update && \
   wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
   echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${LLVM_VERSION} main" >> /etc/apt/sources.list && \
   echo "deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${LLVM_VERSION} main" >> /etc/apt/sources.list && \
-  curl -sL https://deb.nodesource.com/setup_22.x | bash - && \
   apt-get update && \
   apt-get install -y --fix-missing --no-install-recommends \
   curl \
@@ -29,7 +28,6 @@ RUN apt-get update && \
   lld-${LLVM_VERSION} \
   libc++-${LLVM_VERSION}-dev \
   libc++abi-${LLVM_VERSION}-dev \
-  nodejs \
   rcs \
   xz-utils \
   rcs \
@@ -43,8 +41,8 @@ RUN apt-get update && \
   rm /usr/lib/llvm-${LLVM_VERSION}/lib/libunwind.so && \
   ln -sf /usr/lib/llvm-${LLVM_VERSION}/lib/libc++.a /usr/x86_64-unknown-linux-gnu/lib/gcc/x86_64-unknown-linux-gnu/4.8.5/libc++.a && \
   cp -r /usr/x86_64-unknown-linux-gnu/lib/gcc/x86_64-unknown-linux-gnu/4.8.5/* /usr/x86_64-unknown-linux-gnu/x86_64-unknown-linux-gnu/sysroot/usr/lib && \
-  npm install --location=global yarn && \
-  npm cache clean --force && \
+  curl -fsSL https://bun.sh/install | bash && \
+  ln -s /root/.bun/bin/bun /usr/local/bin/bun && \
   curl https://sh.rustup.rs -sSf | sh -s -- -y && \
   rm -rf /var/lib/apt/lists/*
 

--- a/__test__/draw.spec.ts
+++ b/__test__/draw.spec.ts
@@ -1,7 +1,6 @@
 import { promises } from 'node:fs'
 import { platform } from 'node:os'
-import { join, dirname } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 
 import ava, { TestFn } from 'ava'
 import PNG from '@jimp/png'
@@ -9,7 +8,7 @@ import PNG from '@jimp/png'
 import { GlobalFonts, createCanvas, Canvas, Image, ImageData, Path2D, SKRSContext2D, DOMMatrix } from '../index'
 import { snapshotImage } from './image-snapshot'
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
+const __dirname = import.meta.dir
 
 const test = ava as TestFn<{
   canvas: Canvas

--- a/__test__/echarts.spec.ts
+++ b/__test__/echarts.spec.ts
@@ -1,5 +1,4 @@
 import { join } from 'node:path'
-import { fileURLToPath } from 'node:url'
 
 import test from 'ava'
 
@@ -8,7 +7,7 @@ import { snapshotImage } from './image-snapshot'
 
 test('echarts-start', async (t) => {
   t.truthy(
-    GlobalFonts.registerFromPath(join(fileURLToPath(import.meta.url), '..', 'fonts', 'iosevka-slab-regular.ttf')),
+    GlobalFonts.registerFromPath(join(import.meta.dir, 'fonts', 'iosevka-slab-regular.ttf')),
     'Register Iosevka font failed',
   )
   if (process.platform !== 'darwin') {

--- a/__test__/filter.spec.ts
+++ b/__test__/filter.spec.ts
@@ -1,6 +1,5 @@
 import { promises as fs, readFileSync } from 'node:fs'
-import { join, dirname } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 
 import ava, { TestFn } from 'ava'
 
@@ -8,7 +7,7 @@ import { createCanvas, Canvas, SKRSContext2D, Image } from '../index'
 
 import { snapshotImage } from './image-snapshot'
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
+const __dirname = import.meta.dir
 
 const test = ava as TestFn<{
   ctx: SKRSContext2D

--- a/__test__/global-fonts.spec.ts
+++ b/__test__/global-fonts.spec.ts
@@ -1,12 +1,11 @@
 import { readFileSync } from 'node:fs'
-import { join, dirname } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 
 import test from 'ava'
 
 import { GlobalFonts, FontKey } from '../index'
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
+const __dirname = import.meta.dir
 const fontPath = join(__dirname, 'fonts', 'SourceSerifPro-Regular.ttf')
 const fontData = readFileSync(fontPath)
 const defaultCount = GlobalFonts.families.length

--- a/__test__/image-snapshot.ts
+++ b/__test__/image-snapshot.ts
@@ -1,13 +1,12 @@
 import { promises as fs } from 'node:fs'
-import { join, dirname } from 'node:path'
+import { join } from 'node:path'
 import { arch } from 'node:os'
-import { fileURLToPath } from 'node:url'
 
 import PNG from '@jimp/png'
 import JPEG from '@jimp/jpeg'
 import { ExecutionContext } from 'ava'
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
+const __dirname = import.meta.dir
 
 const png = PNG()
 const jpeg = JPEG()

--- a/__test__/image.spec.ts
+++ b/__test__/image.spec.ts
@@ -1,6 +1,5 @@
 import { promises as fs } from 'node:fs'
-import { join, dirname } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 
 import test from 'ava'
 
@@ -8,7 +7,7 @@ import { createCanvas, Image, loadImage } from '../index'
 
 import { snapshotImage } from './image-snapshot'
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
+const __dirname = import.meta.dir
 
 async function loadImageFile() {
   return await fs.readFile(join(__dirname, '../example/simple.png'))

--- a/__test__/index.spec.ts
+++ b/__test__/index.spec.ts
@@ -1,5 +1,4 @@
-import { join, dirname } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 
 import ava, { TestFn } from 'ava'
 
@@ -7,7 +6,7 @@ import { createCanvas, Path2D, Canvas, SKRSContext2D, DOMMatrix, loadImage } fro
 
 import { snapshotImage } from './image-snapshot'
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
+const __dirname = import.meta.dir
 
 const test = ava as TestFn<{
   canvas: Canvas

--- a/__test__/loadimage.spec.ts
+++ b/__test__/loadimage.spec.ts
@@ -1,7 +1,7 @@
-import { join, dirname } from 'node:path'
+import { join } from 'node:path'
 import fs from 'node:fs'
 import { readFile } from 'node:fs/promises'
-import { URL, pathToFileURL, fileURLToPath } from 'node:url'
+import { URL, pathToFileURL } from 'node:url'
 
 import test from 'ava'
 
@@ -9,7 +9,7 @@ import { createCanvas, Image, loadImage } from '../index'
 
 import { snapshotImage } from './image-snapshot'
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
+const __dirname = import.meta.dir
 
 test('should load file src', async (t) => {
   const img = await loadImage(join(__dirname, '../example/simple.png'))

--- a/__test__/node-canvas-compat.spec.ts
+++ b/__test__/node-canvas-compat.spec.ts
@@ -1,6 +1,5 @@
 import { Readable } from 'node:stream'
-import { join, dirname } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 
 import test from 'ava'
 
@@ -22,7 +21,7 @@ import {
   GlobalFonts,
 } from '../node-canvas'
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
+const __dirname = import.meta.dir
 const fontPath = join(__dirname, 'fonts', 'SourceSerifPro-Regular.ttf')
 
 // ---------------------------------------------------------------------------

--- a/__test__/node-canvas-cross-compat.spec.ts
+++ b/__test__/node-canvas-cross-compat.spec.ts
@@ -14,8 +14,7 @@
  */
 
 import { Readable } from 'node:stream'
-import { join, dirname } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 import { createRequire } from 'node:module'
 
 import test from 'ava'
@@ -54,7 +53,7 @@ const hasNodeCanvas = !!ncCreateCanvas
 const ctest = hasNodeCanvas ? test : test.skip
 const cserial = hasNodeCanvas ? test.serial : test.serial.skip
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
+const __dirname = import.meta.dir
 const fontPath = join(__dirname, 'fonts', 'SourceSerifPro-Regular.ttf')
 const latoFontPath = join(__dirname, 'fonts', 'Lato-Regular.ttf')
 const iosevkaFontPath = join(__dirname, 'fonts', 'iosevka-slab-regular.ttf')

--- a/__test__/pdf-annotations.spec.ts
+++ b/__test__/pdf-annotations.spec.ts
@@ -1,12 +1,11 @@
 import { writeFile } from 'node:fs/promises'
-import { join, dirname } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 
 import ava, { TestFn } from 'ava'
 
 import { PDFDocument } from '../index'
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
+const __dirname = import.meta.dir
 
 const test = ava as TestFn<{
   doc: PDFDocument

--- a/__test__/pdf.spec.ts
+++ b/__test__/pdf.spec.ts
@@ -1,12 +1,11 @@
 import { writeFile } from 'node:fs/promises'
-import { join, dirname } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 
 import ava, { TestFn } from 'ava'
 
 import { PDFDocument, GlobalFonts } from '../index'
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
+const __dirname = import.meta.dir
 
 const test = ava as TestFn<{
   doc: PDFDocument

--- a/__test__/regression.spec.ts
+++ b/__test__/regression.spec.ts
@@ -1,6 +1,5 @@
 import { promises as fs } from 'node:fs'
-import { join, dirname } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 
 import test from 'ava'
 import PNG from '@jimp/png'
@@ -8,7 +7,7 @@ import PNG from '@jimp/png'
 import { createCanvas, loadImage, GlobalFonts, Image, ImageData, DOMMatrix, DOMPoint } from '../index'
 import { snapshotImage } from './image-snapshot'
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
+const __dirname = import.meta.dir
 
 // https://github.com/Brooooooklyn/canvas/issues/1250
 test('drawImage with imageSmoothingEnabled should not produce gray halo around transparent PNG edges', async (t) => {

--- a/__test__/stress-memory-leaks.spec.ts
+++ b/__test__/stress-memory-leaks.spec.ts
@@ -1,5 +1,4 @@
-import { join, dirname } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 import { readFileSync, unlinkSync, existsSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 
@@ -19,7 +18,7 @@ const shouldSkip = process.env.RUN_STRESS_TESTS !== 'true'
 
 const test = shouldSkip ? ava.skip : ava
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
+const __dirname = import.meta.dir
 const ITERATIONS = 500
 
 // ============================================================================

--- a/__test__/svg-canvas.spec.ts
+++ b/__test__/svg-canvas.spec.ts
@@ -1,11 +1,10 @@
-import { join, dirname } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 
 import ava, { TestFn } from 'ava'
 
 import { createCanvas, SvgCanvas, SvgExportFlag, GlobalFonts } from '../index'
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
+const __dirname = import.meta.dir
 
 const test = ava as TestFn<{
   canvas: SvgCanvas

--- a/__test__/svg.spec.ts
+++ b/__test__/svg.spec.ts
@@ -1,12 +1,11 @@
-import { join, dirname } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 import { readFileSync, promises as fs } from 'node:fs'
 
 import test from 'ava'
 
 import { convertSVGTextToPath, GlobalFonts } from '../index'
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
+const __dirname = import.meta.dir
 
 const FIXTURE = readFileSync(join(__dirname, 'text.svg'), 'utf8')
 

--- a/__test__/text.spec.ts
+++ b/__test__/text.spec.ts
@@ -1,12 +1,11 @@
-import { join, dirname } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 
 import ava, { TestFn } from 'ava'
 
 import { GlobalFonts, createCanvas, Canvas, SKRSContext2D, type CanvasTextAlign } from '../index'
 import { snapshotImage } from './image-snapshot'
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
+const __dirname = import.meta.dir
 
 const test = ava as TestFn<{
   canvas: Canvas

--- a/__test__/variable-fonts.spec.ts
+++ b/__test__/variable-fonts.spec.ts
@@ -1,11 +1,10 @@
-import { join, dirname } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 
 import test from 'ava'
 
 import { GlobalFonts, Canvas } from '../index.js'
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
+const __dirname = import.meta.dir
 
 // This test demonstrates the new variable font support
 // It requires a variable font to be present in the test fonts directory

--- a/benchmark/gradient.ts
+++ b/benchmark/gradient.ts
@@ -1,56 +1,57 @@
-import { createCanvas, Canvas } from 'canvas'
-import { cyan } from 'colorette'
-import { Bench } from 'tinybench'
-import { Canvas as SkiaCanvas } from 'skia-canvas'
+import { createCanvas, Canvas } from "canvas";
+import { Bench } from "tinybench";
 
-import { createCanvas as skiaCreateCanvas } from '../index'
+const cyan = (s: string) => `\x1b[36m${s}\x1b[0m`;
+import { Canvas as SkiaCanvas } from "skia-canvas";
+
+import { createCanvas as skiaCreateCanvas } from "../index";
 
 function drawGradient(factory: (width: number, height: number) => Canvas) {
-  const canvas = factory(1024, 768)
+  const canvas = factory(1024, 768);
 
-  const ctx = canvas.getContext('2d')!
+  const ctx = canvas.getContext("2d")!;
 
-  const gradient = ctx.createLinearGradient(20, 0, 220, 0)
+  const gradient = ctx.createLinearGradient(20, 0, 220, 0);
 
   // Add three color stops
-  gradient.addColorStop(0, 'green')
-  gradient.addColorStop(0.5, 'cyan')
-  gradient.addColorStop(1, 'green')
+  gradient.addColorStop(0, "green");
+  gradient.addColorStop(0.5, "cyan");
+  gradient.addColorStop(1, "green");
 
   // Set the fill style and draw a rectangle
-  ctx.fillStyle = gradient
-  ctx.fillRect(20, 20, 200, 100)
+  ctx.fillStyle = gradient;
+  ctx.fillRect(20, 20, 200, 100);
 
   if (canvas instanceof SkiaCanvas) {
-    canvas.toBufferSync('png')
+    canvas.toBufferSync("png");
   } else {
     // @ts-expect-error
-    canvas.async = false
-    canvas.toBuffer('image/png')
+    canvas.async = false;
+    canvas.toBuffer("image/png");
   }
 }
 
 export async function gradient() {
   const bench = new Bench({
-    name: 'gradient',
-  })
+    name: "gradient",
+  });
 
   bench
-    .add('@napi-rs/skia', () => {
+    .add("@napi-rs/skia", () => {
       // @ts-expect-error
-      drawGradient(skiaCreateCanvas)
+      drawGradient(skiaCreateCanvas);
     })
-    .add('skia-canvas', () => {
+    .add("skia-canvas", () => {
       // @ts-expect-error
-      drawGradient((w, h) => new SkiaCanvas(w, h))
+      drawGradient((w, h) => new SkiaCanvas(w, h));
     })
-    .add('node-canvas', () => {
-      drawGradient(createCanvas)
-    })
+    .add("node-canvas", () => {
+      drawGradient(createCanvas);
+    });
 
-  await bench.run()
-  console.info(cyan('Draw Gradient and export to PNG'))
-  console.table(bench.table())
+  await bench.run();
+  console.info(cyan("Draw Gradient and export to PNG"));
+  console.table(bench.table());
 
-  return bench
+  return bench;
 }

--- a/benchmark/house.ts
+++ b/benchmark/house.ts
@@ -1,64 +1,65 @@
-import { createCanvas, Canvas } from 'canvas'
-import { cyan } from 'colorette'
-import { Bench } from 'tinybench'
-import { Canvas as SkiaCanvas } from 'skia-canvas'
+import { createCanvas, Canvas } from "canvas";
+import { Bench } from "tinybench";
+import { Canvas as SkiaCanvas } from "skia-canvas";
 
-import { createCanvas as skiaCreateCanvas } from '../index'
+import { createCanvas as skiaCreateCanvas } from "../index";
+
+const cyan = (s: string) => `\x1b[36m${s}\x1b[0m`;
 
 function drawHouse(factory: (width: number, height: number) => Canvas) {
-  const canvas = factory(1024, 768)
+  const canvas = factory(1024, 768);
 
-  const ctx = canvas.getContext('2d')!
+  const ctx = canvas.getContext("2d")!;
 
-  ctx.lineWidth = 10
-  ctx.strokeStyle = '#03a9f4'
-  ctx.fillStyle = '#03a9f4'
+  ctx.lineWidth = 10;
+  ctx.strokeStyle = "#03a9f4";
+  ctx.fillStyle = "#03a9f4";
 
   // Wall
-  ctx.strokeRect(75, 140, 150, 110)
+  ctx.strokeRect(75, 140, 150, 110);
 
   // Door
-  ctx.fillRect(130, 190, 40, 60)
+  ctx.fillRect(130, 190, 40, 60);
 
   // Roof
-  ctx.beginPath()
-  ctx.moveTo(50, 140)
-  ctx.lineTo(150, 60)
-  ctx.lineTo(250, 140)
-  ctx.closePath()
-  ctx.stroke()
+  ctx.beginPath();
+  ctx.moveTo(50, 140);
+  ctx.lineTo(150, 60);
+  ctx.lineTo(250, 140);
+  ctx.closePath();
+  ctx.stroke();
 
   if (canvas instanceof SkiaCanvas) {
-    canvas.toBufferSync('png')
+    canvas.toBufferSync("png");
   } else {
     // @ts-expect-error
-    canvas.async = false
-    canvas.toBuffer('image/png')
+    canvas.async = false;
+    canvas.toBuffer("image/png");
   }
 }
 
 export async function house() {
   const bench = new Bench({
-    name: 'house',
-  })
+    name: "house",
+  });
 
   bench
-    .add('@napi-rs/skia', () => {
+    .add("@napi-rs/skia", () => {
       // @ts-expect-error
-      drawHouse(skiaCreateCanvas)
+      drawHouse(skiaCreateCanvas);
     })
-    .add('skia-canvas', () => {
+    .add("skia-canvas", () => {
       // @ts-expect-error
-      drawHouse((w, h) => new SkiaCanvas(w, h))
+      drawHouse((w, h) => new SkiaCanvas(w, h));
     })
-    .add('node-canvas', () => {
-      drawHouse(createCanvas)
-    })
+    .add("node-canvas", () => {
+      drawHouse(createCanvas);
+    });
 
-  await bench.run()
+  await bench.run();
 
-  console.info(cyan('Draw a House and export to PNG'))
-  console.table(bench.table())
+  console.info(cyan("Draw a House and export to PNG"));
+  console.table(bench.table());
 
-  return bench
+  return bench;
 }

--- a/e2e/webpack/package.json
+++ b/e2e/webpack/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@napi-rs/canvas-e2e-webpack",
+  "name": "@aphrody-code/canvas-e2e-webpack",
   "version": "1.0.0",
-  "description": "E2E test for @napi-rs/canvas with webpack bundling",
+  "description": "E2E test for @aphrody-code/canvas with webpack bundling",
   "private": true,
   "main": "index.js",
   "scripts": {
@@ -15,10 +15,10 @@
     "webpack-cli": "^7.0.0"
   },
   "dependencies": {
-    "@napi-rs/canvas": "workspace:*",
+    "@aphrody-code/canvas": "workspace:*",
     "node-loader": "^2.1.0"
   },
   "resolutions": {
-    "@napi-rs/canvas": "workspace:*"
+    "@aphrody-code/canvas": "workspace:*"
   }
 }

--- a/e2e/webpack/src/index.js
+++ b/e2e/webpack/src/index.js
@@ -1,7 +1,7 @@
 // E2E test for PDF rendering with pdfjs-dist and @napi-rs/canvas
 // This test verifies that pdfjs-dist can render PDFs to canvas in a webpack bundle
 
-import fs from 'fs';
+import fs from 'node:fs';
 import { createCanvas } from '@napi-rs/canvas';
 
 const init = async () => {

--- a/example/anime-girl.js
+++ b/example/anime-girl.js
@@ -1,6 +1,6 @@
-const fs = require('fs').promises
-const { join } = require('path')
-const { performance } = require('perf_hooks')
+const fs = require('node:fs').promises
+const { join } = require('node:path')
+const { performance } = require('node:perf_hooks')
 
 const { createCanvas, Image } = require('../index')
 /* eslint-disable no-console */

--- a/example/draw-emoji.js
+++ b/example/draw-emoji.js
@@ -1,5 +1,5 @@
-const { writeFileSync } = require('fs')
-const { join } = require('path')
+const { writeFileSync } = require('node:fs')
+const { join } = require('node:path')
 
 const { createCanvas, GlobalFonts } = require('../index.js')
 

--- a/example/draw-text-with-baseline.js
+++ b/example/draw-text-with-baseline.js
@@ -1,5 +1,5 @@
-const { writeFileSync } = require('fs')
-const { join } = require('path')
+const { writeFileSync } = require('node:fs')
+const { join } = require('node:path')
 
 const { createCanvas, GlobalFonts } = require('../index.js')
 

--- a/example/draw-text.js
+++ b/example/draw-text.js
@@ -1,5 +1,5 @@
-const { readFileSync, writeFileSync } = require('fs')
-const { join } = require('path')
+const { readFileSync, writeFileSync } = require('node:fs')
+const { join } = require('node:path')
 
 const { createCanvas, GlobalFonts } = require('../index.js')
 

--- a/example/image-data.js
+++ b/example/image-data.js
@@ -1,5 +1,5 @@
-const { promises } = require('fs')
-const { join } = require('path')
+const { promises } = require('node:fs')
+const { join } = require('node:path')
 const PNGReader = require('png.js')
 
 const { createCanvas, ImageData } = require('../index')

--- a/example/image.js
+++ b/example/image.js
@@ -1,5 +1,5 @@
-const { promises } = require('fs')
-const { join } = require('path')
+const { promises } = require('node:fs')
+const { join } = require('node:path')
 
 const { createCanvas, Image } = require('../index')
 

--- a/example/measure-text.js
+++ b/example/measure-text.js
@@ -1,4 +1,4 @@
-const { join } = require('path')
+const { join } = require('node:path')
 
 const { createCanvas, GlobalFonts } = require('../index.js')
 

--- a/example/path-empty-line-to.js
+++ b/example/path-empty-line-to.js
@@ -1,5 +1,5 @@
-const fs = require('fs').promises
-const { join } = require('path')
+const fs = require('node:fs').promises
+const { join } = require('node:path')
 
 const { createCanvas } = require('../index')
 /* eslint-disable no-console */

--- a/example/resize-svg.js
+++ b/example/resize-svg.js
@@ -1,5 +1,5 @@
-const { promises } = require('fs')
-const { join } = require('path')
+const { promises } = require('node:fs')
+const { join } = require('node:path')
 
 const { createCanvas, Image } = require('../index')
 

--- a/example/round-path.js
+++ b/example/round-path.js
@@ -1,5 +1,5 @@
-const { writeFileSync } = require('fs')
-const { join } = require('path')
+const { writeFileSync } = require('node:fs')
+const { join } = require('node:path')
 
 const { createCanvas, Path2D } = require('../index.js')
 

--- a/example/simple.js
+++ b/example/simple.js
@@ -1,5 +1,5 @@
-const { promises } = require('fs')
-const { join } = require('path')
+const { promises } = require('node:fs')
+const { join } = require('node:path')
 const { createCanvas } = require('../index')
 
 const canvas = createCanvas(300, 320)

--- a/example/tiger.js
+++ b/example/tiger.js
@@ -1,5 +1,5 @@
-const { promises } = require('fs')
-const { join } = require('path')
+const { promises } = require('node:fs')
+const { join } = require('node:path')
 
 const { createCanvas, Path2D } = require('../index')
 

--- a/geometry.js
+++ b/geometry.js
@@ -1,4 +1,4 @@
-const { inspect } = require('util')
+const { inspect } = require("node:util");
 /*
  * vendored in order to fix its dependence on the window global [cds 2020/08/04]
  * otherwise unchanged from https://github.com/jarek-foksa/geometry-polyfill/tree/f36bbc8f4bc43539d980687904ce46c8e915543d
@@ -11,10 +11,10 @@ const { inspect } = require('util')
 //   https://github.com/chromium/chromium/blob/master/third_party/blink/renderer/core/geometry/dom_point_read_only.cc
 class DOMPoint {
   constructor(x = 0, y = 0, z = 0, w = 1) {
-    this.x = x
-    this.y = y
-    this.z = z
-    this.w = w
+    this.x = x;
+    this.y = y;
+    this.z = z;
+    this.w = w;
   }
 
   static fromPoint(otherPoint) {
@@ -23,7 +23,7 @@ class DOMPoint {
       otherPoint.y,
       otherPoint.z !== undefined ? otherPoint.z : 0,
       otherPoint.w !== undefined ? otherPoint.w : 1,
-    )
+    );
   }
 
   matrixTransform(matrix) {
@@ -33,14 +33,14 @@ class DOMPoint {
         this.x * matrix.b + this.y * matrix.d + matrix.f,
         0,
         1,
-      )
+      );
     } else {
       return new DOMPoint(
         this.x * matrix.m11 + this.y * matrix.m21 + this.z * matrix.m31 + this.w * matrix.m41,
         this.x * matrix.m12 + this.y * matrix.m22 + this.z * matrix.m32 + this.w * matrix.m42,
         this.x * matrix.m13 + this.y * matrix.m23 + this.z * matrix.m33 + this.w * matrix.m43,
         this.x * matrix.m14 + this.y * matrix.m24 + this.z * matrix.m34 + this.w * matrix.m44,
-      )
+      );
     }
   }
 
@@ -50,7 +50,7 @@ class DOMPoint {
       y: this.y,
       z: this.z,
       w: this.w,
-    }
+    };
   }
 }
 
@@ -62,30 +62,30 @@ class DOMPoint {
 
 class DOMRect {
   constructor(x = 0, y = 0, width = 0, height = 0) {
-    this.x = x
-    this.y = y
-    this.width = width
-    this.height = height
+    this.x = x;
+    this.y = y;
+    this.width = width;
+    this.height = height;
   }
 
   static fromRect(otherRect) {
-    return new DOMRect(otherRect.x, otherRect.y, otherRect.width, otherRect.height)
+    return new DOMRect(otherRect.x, otherRect.y, otherRect.width, otherRect.height);
   }
 
   get top() {
-    return this.y
+    return this.y;
   }
 
   get left() {
-    return this.x
+    return this.x;
   }
 
   get right() {
-    return this.x + this.width
+    return this.x + this.width;
   }
 
   get bottom() {
-    return this.y + this.height
+    return this.y + this.height;
   }
 
   toJSON() {
@@ -98,14 +98,14 @@ class DOMRect {
       left: this.left,
       right: this.right,
       bottom: this.bottom,
-    }
+    };
   }
 }
 
-for (const propertyName of ['top', 'right', 'bottom', 'left']) {
-  const propertyDescriptor = Object.getOwnPropertyDescriptor(DOMRect.prototype, propertyName)
-  propertyDescriptor.enumerable = true
-  Object.defineProperty(DOMRect.prototype, propertyName, propertyDescriptor)
+for (const propertyName of ["top", "right", "bottom", "left"]) {
+  const propertyDescriptor = Object.getOwnPropertyDescriptor(DOMRect.prototype, propertyName);
+  propertyDescriptor.enumerable = true;
+  Object.defineProperty(DOMRect.prototype, propertyName, propertyDescriptor);
 }
 
 // @info
@@ -117,259 +117,276 @@ for (const propertyName of ['top', 'right', 'bottom', 'left']) {
 const M11 = 0,
   M12 = 1,
   M13 = 2,
-  M14 = 3
+  M14 = 3;
 const M21 = 4,
   M22 = 5,
   M23 = 6,
-  M24 = 7
+  M24 = 7;
 const M31 = 8,
   M32 = 9,
   M33 = 10,
-  M34 = 11
+  M34 = 11;
 const M41 = 12,
   M42 = 13,
   M43 = 14,
-  M44 = 15
+  M44 = 15;
 
 const A = M11,
-  B = M12
+  B = M12;
 const C = M21,
-  D = M22
+  D = M22;
 const E = M41,
-  F = M42
+  F = M42;
 
-const DEGREE_PER_RAD = 180 / Math.PI
-const RAD_PER_DEGREE = Math.PI / 180
+const DEGREE_PER_RAD = 180 / Math.PI;
+const RAD_PER_DEGREE = Math.PI / 180;
 
-const VALUES = Symbol('values')
-const IS_2D = Symbol('is2D')
+const VALUES = Symbol("values");
+const IS_2D = Symbol("is2D");
 
 function parseMatrix(init) {
-  let parsed = init.replace(/matrix\(/, '').split(/,/, 7)
+  let parsed = init.replace(/matrix\(/, "").split(/,/, 7);
 
   if (parsed.length !== 6) {
-    throw new Error(`Failed to parse ${init}`)
+    throw new Error(`Failed to parse ${init}`);
   }
 
-  parsed = parsed.map(parseFloat)
+  parsed = parsed.map(parseFloat);
 
-  return [parsed[0], parsed[1], 0, 0, parsed[2], parsed[3], 0, 0, 0, 0, 1, 0, parsed[4], parsed[5], 0, 1]
+  return [
+    parsed[0],
+    parsed[1],
+    0,
+    0,
+    parsed[2],
+    parsed[3],
+    0,
+    0,
+    0,
+    0,
+    1,
+    0,
+    parsed[4],
+    parsed[5],
+    0,
+    1,
+  ];
 }
 
 function parseMatrix3d(init) {
-  const parsed = init.replace(/matrix3d\(/, '').split(/,/, 17)
+  const parsed = init.replace(/matrix3d\(/, "").split(/,/, 17);
 
   if (parsed.length !== 16) {
-    throw new Error(`Failed to parse ${init}`)
+    throw new Error(`Failed to parse ${init}`);
   }
 
-  return parsed.map(parseFloat)
+  return parsed.map(parseFloat);
 }
 
 function parseTransform(tform) {
-  const type = tform.split(/\(/, 1)[0]
+  const type = tform.split(/\(/, 1)[0];
 
-  if (type === 'matrix') {
-    return parseMatrix(tform)
-  } else if (type === 'matrix3d') {
-    return parseMatrix3d(tform)
+  if (type === "matrix") {
+    return parseMatrix(tform);
+  } else if (type === "matrix3d") {
+    return parseMatrix3d(tform);
   } else {
-    throw new Error(`${type} parsing not implemented`)
+    throw new Error(`${type} parsing not implemented`);
   }
 }
 
 const setNumber2D = (receiver, index, value) => {
-  if (typeof value !== 'number') {
-    throw new TypeError('Expected number')
+  if (typeof value !== "number") {
+    throw new TypeError("Expected number");
   }
 
-  receiver[VALUES][index] = value
-}
+  receiver[VALUES][index] = value;
+};
 
 const setNumber3D = (receiver, index, value) => {
-  if (typeof value !== 'number') {
-    throw new TypeError('Expected number')
+  if (typeof value !== "number") {
+    throw new TypeError("Expected number");
   }
 
   if (index === M33 || index === M44) {
     if (value !== 1) {
-      receiver[IS_2D] = false
+      receiver[IS_2D] = false;
     }
   } else if (value !== 0) {
-    receiver[IS_2D] = false
+    receiver[IS_2D] = false;
   }
 
-  receiver[VALUES][index] = value
-}
+  receiver[VALUES][index] = value;
+};
 
 const newInstance = (values) => {
-  const instance = Object.create(DOMMatrix.prototype)
-  instance.constructor = DOMMatrix
-  instance[IS_2D] = true
-  instance[VALUES] = values
+  const instance = Object.create(DOMMatrix.prototype);
+  instance.constructor = DOMMatrix;
+  instance[IS_2D] = true;
+  instance[VALUES] = values;
 
-  return instance
-}
+  return instance;
+};
 
 const multiply = (first, second) => {
-  const dest = new Float64Array(16)
+  const dest = new Float64Array(16);
 
   for (let i = 0; i < 4; i++) {
     for (let j = 0; j < 4; j++) {
-      let sum = 0
+      let sum = 0;
 
       for (let k = 0; k < 4; k++) {
-        sum += first[i * 4 + k] * second[k * 4 + j]
+        sum += first[i * 4 + k] * second[k * 4 + j];
       }
 
-      dest[i * 4 + j] = sum
+      dest[i * 4 + j] = sum;
     }
   }
 
-  return dest
-}
+  return dest;
+};
 
 class DOMMatrix {
   get m11() {
-    return this[VALUES][M11]
+    return this[VALUES][M11];
   }
   set m11(value) {
-    setNumber2D(this, M11, value)
+    setNumber2D(this, M11, value);
   }
   get m12() {
-    return this[VALUES][M12]
+    return this[VALUES][M12];
   }
   set m12(value) {
-    setNumber2D(this, M12, value)
+    setNumber2D(this, M12, value);
   }
   get m13() {
-    return this[VALUES][M13]
+    return this[VALUES][M13];
   }
   set m13(value) {
-    setNumber3D(this, M13, value)
+    setNumber3D(this, M13, value);
   }
   get m14() {
-    return this[VALUES][M14]
+    return this[VALUES][M14];
   }
   set m14(value) {
-    setNumber3D(this, M14, value)
+    setNumber3D(this, M14, value);
   }
   get m21() {
-    return this[VALUES][M21]
+    return this[VALUES][M21];
   }
   set m21(value) {
-    setNumber2D(this, M21, value)
+    setNumber2D(this, M21, value);
   }
   get m22() {
-    return this[VALUES][M22]
+    return this[VALUES][M22];
   }
   set m22(value) {
-    setNumber2D(this, M22, value)
+    setNumber2D(this, M22, value);
   }
   get m23() {
-    return this[VALUES][M23]
+    return this[VALUES][M23];
   }
   set m23(value) {
-    setNumber3D(this, M23, value)
+    setNumber3D(this, M23, value);
   }
   get m24() {
-    return this[VALUES][M24]
+    return this[VALUES][M24];
   }
   set m24(value) {
-    setNumber3D(this, M24, value)
+    setNumber3D(this, M24, value);
   }
   get m31() {
-    return this[VALUES][M31]
+    return this[VALUES][M31];
   }
   set m31(value) {
-    setNumber3D(this, M31, value)
+    setNumber3D(this, M31, value);
   }
   get m32() {
-    return this[VALUES][M32]
+    return this[VALUES][M32];
   }
   set m32(value) {
-    setNumber3D(this, M32, value)
+    setNumber3D(this, M32, value);
   }
   get m33() {
-    return this[VALUES][M33]
+    return this[VALUES][M33];
   }
   set m33(value) {
-    setNumber3D(this, M33, value)
+    setNumber3D(this, M33, value);
   }
   get m34() {
-    return this[VALUES][M34]
+    return this[VALUES][M34];
   }
   set m34(value) {
-    setNumber3D(this, M34, value)
+    setNumber3D(this, M34, value);
   }
   get m41() {
-    return this[VALUES][M41]
+    return this[VALUES][M41];
   }
   set m41(value) {
-    setNumber2D(this, M41, value)
+    setNumber2D(this, M41, value);
   }
   get m42() {
-    return this[VALUES][M42]
+    return this[VALUES][M42];
   }
   set m42(value) {
-    setNumber2D(this, M42, value)
+    setNumber2D(this, M42, value);
   }
   get m43() {
-    return this[VALUES][M43]
+    return this[VALUES][M43];
   }
   set m43(value) {
-    setNumber3D(this, M43, value)
+    setNumber3D(this, M43, value);
   }
   get m44() {
-    return this[VALUES][M44]
+    return this[VALUES][M44];
   }
   set m44(value) {
-    setNumber3D(this, M44, value)
+    setNumber3D(this, M44, value);
   }
 
   get a() {
-    return this[VALUES][A]
+    return this[VALUES][A];
   }
   set a(value) {
-    setNumber2D(this, A, value)
+    setNumber2D(this, A, value);
   }
   get b() {
-    return this[VALUES][B]
+    return this[VALUES][B];
   }
   set b(value) {
-    setNumber2D(this, B, value)
+    setNumber2D(this, B, value);
   }
   get c() {
-    return this[VALUES][C]
+    return this[VALUES][C];
   }
   set c(value) {
-    setNumber2D(this, C, value)
+    setNumber2D(this, C, value);
   }
   get d() {
-    return this[VALUES][D]
+    return this[VALUES][D];
   }
   set d(value) {
-    setNumber2D(this, D, value)
+    setNumber2D(this, D, value);
   }
   get e() {
-    return this[VALUES][E]
+    return this[VALUES][E];
   }
   set e(value) {
-    setNumber2D(this, E, value)
+    setNumber2D(this, E, value);
   }
   get f() {
-    return this[VALUES][F]
+    return this[VALUES][F];
   }
   set f(value) {
-    setNumber2D(this, F, value)
+    setNumber2D(this, F, value);
   }
 
   get is2D() {
-    return this[IS_2D]
+    return this[IS_2D];
   }
 
   get isIdentity() {
-    const values = this[VALUES]
+    const values = this[VALUES];
 
     return (
       values[M11] === 1 &&
@@ -388,99 +405,118 @@ class DOMMatrix {
       values[M42] === 0 &&
       values[M43] === 0 &&
       values[M44] === 1
-    )
+    );
   }
 
   static fromMatrix(init) {
     if (init instanceof DOMMatrix) {
-      return new DOMMatrix(init[VALUES])
+      return new DOMMatrix(init[VALUES]);
     } else if (init instanceof SVGMatrix) {
-      return new DOMMatrix([init.a, init.b, init.c, init.d, init.e, init.f])
+      return new DOMMatrix([init.a, init.b, init.c, init.d, init.e, init.f]);
     } else {
-      throw new TypeError('Expected DOMMatrix')
+      throw new TypeError("Expected DOMMatrix");
     }
   }
 
   static fromFloat32Array(init) {
-    if (!(init instanceof Float32Array)) throw new TypeError('Expected Float32Array')
-    return new DOMMatrix(init)
+    if (!(init instanceof Float32Array)) throw new TypeError("Expected Float32Array");
+    return new DOMMatrix(init);
   }
 
   static fromFloat64Array(init) {
-    if (!(init instanceof Float64Array)) throw new TypeError('Expected Float64Array')
-    return new DOMMatrix(init)
+    if (!(init instanceof Float64Array)) throw new TypeError("Expected Float64Array");
+    return new DOMMatrix(init);
   }
 
   // @type
   // (Float64Array) => void
   constructor(init) {
-    this[IS_2D] = true
+    this[IS_2D] = true;
 
-    this[VALUES] = new Float64Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1])
+    this[VALUES] = new Float64Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
 
     // Parse CSS transformList
-    if (typeof init === 'string') {
-      if (init === '') {
-        return
+    if (typeof init === "string") {
+      if (init === "") {
+        return;
       } else {
-        const tforms = init.split(/\)\s+/, 20).map(parseTransform)
+        const tforms = init.split(/\)\s+/, 20).map(parseTransform);
 
         if (tforms.length === 0) {
-          return
+          return;
         }
 
-        init = tforms[0]
+        init = tforms[0];
 
         for (let i = 1; i < tforms.length; i++) {
-          init = multiply(tforms[i], init)
+          init = multiply(tforms[i], init);
         }
       }
     }
 
-    let i = 0
+    let i = 0;
 
     if (init && init.length === 6) {
-      setNumber2D(this, A, init[i++])
-      setNumber2D(this, B, init[i++])
-      setNumber2D(this, C, init[i++])
-      setNumber2D(this, D, init[i++])
-      setNumber2D(this, E, init[i++])
-      setNumber2D(this, F, init[i++])
+      setNumber2D(this, A, init[i++]);
+      setNumber2D(this, B, init[i++]);
+      setNumber2D(this, C, init[i++]);
+      setNumber2D(this, D, init[i++]);
+      setNumber2D(this, E, init[i++]);
+      setNumber2D(this, F, init[i++]);
     } else if (init && init.length === 16) {
-      setNumber2D(this, M11, init[i++])
-      setNumber2D(this, M12, init[i++])
-      setNumber3D(this, M13, init[i++])
-      setNumber3D(this, M14, init[i++])
-      setNumber2D(this, M21, init[i++])
-      setNumber2D(this, M22, init[i++])
-      setNumber3D(this, M23, init[i++])
-      setNumber3D(this, M24, init[i++])
-      setNumber3D(this, M31, init[i++])
-      setNumber3D(this, M32, init[i++])
-      setNumber3D(this, M33, init[i++])
-      setNumber3D(this, M34, init[i++])
-      setNumber2D(this, M41, init[i++])
-      setNumber2D(this, M42, init[i++])
-      setNumber3D(this, M43, init[i++])
-      setNumber3D(this, M44, init[i])
+      setNumber2D(this, M11, init[i++]);
+      setNumber2D(this, M12, init[i++]);
+      setNumber3D(this, M13, init[i++]);
+      setNumber3D(this, M14, init[i++]);
+      setNumber2D(this, M21, init[i++]);
+      setNumber2D(this, M22, init[i++]);
+      setNumber3D(this, M23, init[i++]);
+      setNumber3D(this, M24, init[i++]);
+      setNumber3D(this, M31, init[i++]);
+      setNumber3D(this, M32, init[i++]);
+      setNumber3D(this, M33, init[i++]);
+      setNumber3D(this, M34, init[i++]);
+      setNumber2D(this, M41, init[i++]);
+      setNumber2D(this, M42, init[i++]);
+      setNumber3D(this, M43, init[i++]);
+      setNumber3D(this, M44, init[i]);
     } else if (init !== undefined) {
-      throw new TypeError('Expected string or array.')
+      throw new TypeError("Expected string or array.");
     }
   }
 
   dump() {
-    const mat = this[VALUES]
-    console.info([mat.slice(0, 4), mat.slice(4, 8), mat.slice(8, 12), mat.slice(12, 16)])
+    const mat = this[VALUES];
+    console.info([mat.slice(0, 4), mat.slice(4, 8), mat.slice(8, 12), mat.slice(12, 16)]);
   }
 
   [inspect.custom](depth) {
-    if (depth < 0) return '[DOMMatrix]'
+    if (depth < 0) return "[DOMMatrix]";
 
-    const { a, b, c, d, e, f, is2D, isIdentity } = this
+    const { a, b, c, d, e, f, is2D, isIdentity } = this;
     if (this.is2D) {
-      return `DOMMatrix ${inspect({ a, b, c, d, e, f, is2D, isIdentity }, { colors: true })}`
+      return `DOMMatrix ${inspect({ a, b, c, d, e, f, is2D, isIdentity }, { colors: true })}`;
     } else {
-      const { m11, m12, m13, m14, m21, m22, m23, m24, m31, m32, m33, m34, m41, m42, m43, m44, is2D, isIdentity } = this
+      const {
+        m11,
+        m12,
+        m13,
+        m14,
+        m21,
+        m22,
+        m23,
+        m24,
+        m31,
+        m32,
+        m33,
+        m34,
+        m41,
+        m42,
+        m43,
+        m44,
+        is2D,
+        isIdentity,
+      } = this;
       return `DOMMatrix ${inspect(
         {
           a,
@@ -509,155 +545,158 @@ class DOMMatrix {
           isIdentity,
         },
         { colors: true },
-      )}`
+      )}`;
     }
   }
 
   multiply(other) {
-    return newInstance(this[VALUES]).multiplySelf(other)
+    return newInstance(this[VALUES]).multiplySelf(other);
   }
 
   multiplySelf(other) {
-    this[VALUES] = multiply(other[VALUES], this[VALUES])
+    this[VALUES] = multiply(other[VALUES], this[VALUES]);
 
     if (!other.is2D) {
-      this[IS_2D] = false
+      this[IS_2D] = false;
     }
 
-    return this
+    return this;
   }
 
   preMultiplySelf(other) {
-    this[VALUES] = multiply(this[VALUES], other[VALUES])
+    this[VALUES] = multiply(this[VALUES], other[VALUES]);
 
     if (!other.is2D) {
-      this[IS_2D] = false
+      this[IS_2D] = false;
     }
 
-    return this
+    return this;
   }
 
   translate(tx, ty, tz) {
-    return newInstance(this[VALUES]).translateSelf(tx, ty, tz)
+    return newInstance(this[VALUES]).translateSelf(tx, ty, tz);
   }
 
   translateSelf(tx = 0, ty = 0, tz = 0) {
-    this[VALUES] = multiply([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, tx, ty, tz, 1], this[VALUES])
+    this[VALUES] = multiply([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, tx, ty, tz, 1], this[VALUES]);
 
     if (tz !== 0) {
-      this[IS_2D] = false
+      this[IS_2D] = false;
     }
 
-    return this
+    return this;
   }
 
   scale(scaleX, scaleY, scaleZ, originX, originY, originZ) {
-    return newInstance(this[VALUES]).scaleSelf(scaleX, scaleY, scaleZ, originX, originY, originZ)
+    return newInstance(this[VALUES]).scaleSelf(scaleX, scaleY, scaleZ, originX, originY, originZ);
   }
 
   scale3d(scale, originX, originY, originZ) {
-    return newInstance(this[VALUES]).scale3dSelf(scale, originX, originY, originZ)
+    return newInstance(this[VALUES]).scale3dSelf(scale, originX, originY, originZ);
   }
 
   scale3dSelf(scale, originX, originY, originZ) {
-    return this.scaleSelf(scale, scale, scale, originX, originY, originZ)
+    return this.scaleSelf(scale, scale, scale, originX, originY, originZ);
   }
 
   scaleSelf(scaleX, scaleY, scaleZ, originX, originY, originZ) {
     // Not redundant with translate's checks because we need to negate the values later.
-    if (typeof originX !== 'number') originX = 0
-    if (typeof originY !== 'number') originY = 0
-    if (typeof originZ !== 'number') originZ = 0
+    if (typeof originX !== "number") originX = 0;
+    if (typeof originY !== "number") originY = 0;
+    if (typeof originZ !== "number") originZ = 0;
 
-    this.translateSelf(originX, originY, originZ)
+    this.translateSelf(originX, originY, originZ);
 
-    if (typeof scaleX !== 'number') scaleX = 1
-    if (typeof scaleY !== 'number') scaleY = scaleX
-    if (typeof scaleZ !== 'number') scaleZ = 1
+    if (typeof scaleX !== "number") scaleX = 1;
+    if (typeof scaleY !== "number") scaleY = scaleX;
+    if (typeof scaleZ !== "number") scaleZ = 1;
 
-    this[VALUES] = multiply([scaleX, 0, 0, 0, 0, scaleY, 0, 0, 0, 0, scaleZ, 0, 0, 0, 0, 1], this[VALUES])
+    this[VALUES] = multiply(
+      [scaleX, 0, 0, 0, 0, scaleY, 0, 0, 0, 0, scaleZ, 0, 0, 0, 0, 1],
+      this[VALUES],
+    );
 
-    this.translateSelf(-originX, -originY, -originZ)
+    this.translateSelf(-originX, -originY, -originZ);
 
     if (scaleZ !== 1 || originZ !== 0) {
-      this[IS_2D] = false
+      this[IS_2D] = false;
     }
 
-    return this
+    return this;
   }
 
   rotateFromVector(x, y) {
-    return newInstance(this[VALUES]).rotateFromVectorSelf(x, y)
+    return newInstance(this[VALUES]).rotateFromVectorSelf(x, y);
   }
 
   rotateFromVectorSelf(x = 0, y = 0) {
-    const theta = x === 0 && y === 0 ? 0 : Math.atan2(y, x) * DEGREE_PER_RAD
-    return this.rotateSelf(theta)
+    const theta = x === 0 && y === 0 ? 0 : Math.atan2(y, x) * DEGREE_PER_RAD;
+    return this.rotateSelf(theta);
   }
 
   rotate(rotX, rotY, rotZ) {
-    return newInstance(this[VALUES]).rotateSelf(rotX, rotY, rotZ)
+    return newInstance(this[VALUES]).rotateSelf(rotX, rotY, rotZ);
   }
 
   rotateSelf(rotX, rotY, rotZ) {
     if (rotY === undefined && rotZ === undefined) {
-      rotZ = rotX
-      rotX = rotY = 0
+      rotZ = rotX;
+      rotX = rotY = 0;
     }
 
-    if (typeof rotY !== 'number') rotY = 0
-    if (typeof rotZ !== 'number') rotZ = 0
+    if (typeof rotY !== "number") rotY = 0;
+    if (typeof rotZ !== "number") rotZ = 0;
 
     if (rotX !== 0 || rotY !== 0) {
-      this[IS_2D] = false
+      this[IS_2D] = false;
     }
 
-    rotX *= RAD_PER_DEGREE
-    rotY *= RAD_PER_DEGREE
-    rotZ *= RAD_PER_DEGREE
+    rotX *= RAD_PER_DEGREE;
+    rotY *= RAD_PER_DEGREE;
+    rotZ *= RAD_PER_DEGREE;
 
-    let c = Math.cos(rotZ)
-    let s = Math.sin(rotZ)
+    let c = Math.cos(rotZ);
+    let s = Math.sin(rotZ);
 
-    this[VALUES] = multiply([c, s, 0, 0, -s, c, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1], this[VALUES])
+    this[VALUES] = multiply([c, s, 0, 0, -s, c, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1], this[VALUES]);
 
-    c = Math.cos(rotY)
-    s = Math.sin(rotY)
+    c = Math.cos(rotY);
+    s = Math.sin(rotY);
 
-    this[VALUES] = multiply([c, 0, -s, 0, 0, 1, 0, 0, s, 0, c, 0, 0, 0, 0, 1], this[VALUES])
+    this[VALUES] = multiply([c, 0, -s, 0, 0, 1, 0, 0, s, 0, c, 0, 0, 0, 0, 1], this[VALUES]);
 
-    c = Math.cos(rotX)
-    s = Math.sin(rotX)
+    c = Math.cos(rotX);
+    s = Math.sin(rotX);
 
-    this[VALUES] = multiply([1, 0, 0, 0, 0, c, s, 0, 0, -s, c, 0, 0, 0, 0, 1], this[VALUES])
+    this[VALUES] = multiply([1, 0, 0, 0, 0, c, s, 0, 0, -s, c, 0, 0, 0, 0, 1], this[VALUES]);
 
-    return this
+    return this;
   }
 
   rotateAxisAngle(x, y, z, angle) {
-    return newInstance(this[VALUES]).rotateAxisAngleSelf(x, y, z, angle)
+    return newInstance(this[VALUES]).rotateAxisAngleSelf(x, y, z, angle);
   }
 
   rotateAxisAngleSelf(x = 0, y = 0, z = 0, angle = 0) {
-    const length = Math.sqrt(x * x + y * y + z * z)
+    const length = Math.sqrt(x * x + y * y + z * z);
 
     if (length === 0) {
-      return this
+      return this;
     }
 
     if (length !== 1) {
-      x /= length
-      y /= length
-      z /= length
+      x /= length;
+      y /= length;
+      z /= length;
     }
 
-    angle *= RAD_PER_DEGREE
+    angle *= RAD_PER_DEGREE;
 
-    const c = Math.cos(angle)
-    const s = Math.sin(angle)
-    const t = 1 - c
-    const tx = t * x
-    const ty = t * y
+    const c = Math.cos(angle);
+    const s = Math.sin(angle);
+    const t = 1 - c;
+    const tx = t * x;
+    const ty = t * y;
 
     this[VALUES] = multiply(
       [
@@ -679,126 +718,143 @@ class DOMMatrix {
         1,
       ],
       this[VALUES],
-    )
+    );
 
     if (x !== 0 || y !== 0) {
-      this[IS_2D] = false
+      this[IS_2D] = false;
     }
 
-    return this
+    return this;
   }
 
   skewX(sx) {
-    return newInstance(this[VALUES]).skewXSelf(sx)
+    return newInstance(this[VALUES]).skewXSelf(sx);
   }
 
   skewXSelf(sx) {
-    if (typeof sx !== 'number') {
-      return this
+    if (typeof sx !== "number") {
+      return this;
     }
 
-    const t = Math.tan(sx * RAD_PER_DEGREE)
+    const t = Math.tan(sx * RAD_PER_DEGREE);
 
-    this[VALUES] = multiply([1, 0, 0, 0, t, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1], this[VALUES])
+    this[VALUES] = multiply([1, 0, 0, 0, t, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1], this[VALUES]);
 
-    return this
+    return this;
   }
 
   skewY(sy) {
-    return newInstance(this[VALUES]).skewYSelf(sy)
+    return newInstance(this[VALUES]).skewYSelf(sy);
   }
 
   skewYSelf(sy) {
-    if (typeof sy !== 'number') {
-      return this
+    if (typeof sy !== "number") {
+      return this;
     }
 
-    const t = Math.tan(sy * RAD_PER_DEGREE)
+    const t = Math.tan(sy * RAD_PER_DEGREE);
 
-    this[VALUES] = multiply([1, t, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1], this[VALUES])
+    this[VALUES] = multiply([1, t, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1], this[VALUES]);
 
-    return this
+    return this;
   }
 
   flipX() {
-    return newInstance(multiply([-1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1], this[VALUES]))
+    return newInstance(multiply([-1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1], this[VALUES]));
   }
 
   flipY() {
-    return newInstance(multiply([1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1], this[VALUES]))
+    return newInstance(multiply([1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1], this[VALUES]));
   }
 
   inverse() {
-    return newInstance(this[VALUES].slice()).invertSelf()
+    return newInstance(this[VALUES].slice()).invertSelf();
   }
 
   invertSelf() {
     if (this[IS_2D]) {
-      const det = this[VALUES][A] * this[VALUES][D] - this[VALUES][B] * this[VALUES][C]
+      const det = this[VALUES][A] * this[VALUES][D] - this[VALUES][B] * this[VALUES][C];
 
       // Invertable
       if (det !== 0) {
-        const newA = this[VALUES][D] / det
-        const newB = -this[VALUES][B] / det
-        const newC = -this[VALUES][C] / det
-        const newD = this[VALUES][A] / det
-        const newE = (this[VALUES][C] * this[VALUES][F] - this[VALUES][D] * this[VALUES][E]) / det
-        const newF = (this[VALUES][B] * this[VALUES][E] - this[VALUES][A] * this[VALUES][F]) / det
+        const newA = this[VALUES][D] / det;
+        const newB = -this[VALUES][B] / det;
+        const newC = -this[VALUES][C] / det;
+        const newD = this[VALUES][A] / det;
+        const newE = (this[VALUES][C] * this[VALUES][F] - this[VALUES][D] * this[VALUES][E]) / det;
+        const newF = (this[VALUES][B] * this[VALUES][E] - this[VALUES][A] * this[VALUES][F]) / det;
 
-        this.a = newA
-        this.b = newB
-        this.c = newC
-        this.d = newD
-        this.e = newE
-        this.f = newF
+        this.a = newA;
+        this.b = newB;
+        this.c = newC;
+        this.d = newD;
+        this.e = newE;
+        this.f = newF;
 
-        return this
+        return this;
       }
 
       // Not invertable
       else {
-        this[IS_2D] = false
+        this[IS_2D] = false;
 
-        this[VALUES] = [NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN]
+        this[VALUES] = [
+          NaN,
+          NaN,
+          NaN,
+          NaN,
+          NaN,
+          NaN,
+          NaN,
+          NaN,
+          NaN,
+          NaN,
+          NaN,
+          NaN,
+          NaN,
+          NaN,
+          NaN,
+          NaN,
+        ];
 
-        return this
+        return this;
       }
     } else {
-      throw new Error('3D matrix inversion is not implemented.')
+      throw new Error("3D matrix inversion is not implemented.");
     }
   }
 
   setMatrixValue(transformList) {
-    const temp = new DOMMatrix(transformList)
+    const temp = new DOMMatrix(transformList);
 
-    this[VALUES] = temp[VALUES]
-    this[IS_2D] = temp[IS_2D]
+    this[VALUES] = temp[VALUES];
+    this[IS_2D] = temp[IS_2D];
 
-    return this
+    return this;
   }
 
   transformPoint(point) {
-    const x = point.x || 0
-    const y = point.y || 0
-    const z = point.z || 0
-    const w = point.w || 1
+    const x = point.x || 0;
+    const y = point.y || 0;
+    const z = point.z || 0;
+    const w = point.w || 1;
 
-    const values = this[VALUES]
+    const values = this[VALUES];
 
-    const nx = values[M11] * x + values[M21] * y + values[M31] * z + values[M41] * w
-    const ny = values[M12] * x + values[M22] * y + values[M32] * z + values[M42] * w
-    const nz = values[M13] * x + values[M23] * y + values[M33] * z + values[M43] * w
-    const nw = values[M14] * x + values[M24] * y + values[M34] * z + values[M44] * w
+    const nx = values[M11] * x + values[M21] * y + values[M31] * z + values[M41] * w;
+    const ny = values[M12] * x + values[M22] * y + values[M32] * z + values[M42] * w;
+    const nz = values[M13] * x + values[M23] * y + values[M33] * z + values[M43] * w;
+    const nw = values[M14] * x + values[M24] * y + values[M34] * z + values[M44] * w;
 
-    return new DOMPoint(nx, ny, nz, nw)
+    return new DOMPoint(nx, ny, nz, nw);
   }
 
   toFloat32Array() {
-    return Float32Array.from(this[VALUES])
+    return Float32Array.from(this[VALUES]);
   }
 
   toFloat64Array() {
-    return this[VALUES].slice(0)
+    return this[VALUES].slice(0);
   }
 
   toJSON() {
@@ -827,47 +883,47 @@ class DOMMatrix {
       m44: this.m44,
       is2D: this.is2D,
       isIdentity: this.isIdentity,
-    }
+    };
   }
 
   toString() {
     if (this.is2D) {
-      return `matrix(${this.a}, ${this.b}, ${this.c}, ${this.d}, ${this.e}, ${this.f})`
+      return `matrix(${this.a}, ${this.b}, ${this.c}, ${this.d}, ${this.e}, ${this.f})`;
     } else {
-      return `matrix3d(${this[VALUES].join(', ')})`
+      return `matrix3d(${this[VALUES].join(", ")})`;
     }
   }
 }
 
 for (const propertyName of [
-  'a',
-  'b',
-  'c',
-  'd',
-  'e',
-  'f',
-  'm11',
-  'm12',
-  'm13',
-  'm14',
-  'm21',
-  'm22',
-  'm23',
-  'm24',
-  'm31',
-  'm32',
-  'm33',
-  'm34',
-  'm41',
-  'm42',
-  'm43',
-  'm44',
-  'is2D',
-  'isIdentity',
+  "a",
+  "b",
+  "c",
+  "d",
+  "e",
+  "f",
+  "m11",
+  "m12",
+  "m13",
+  "m14",
+  "m21",
+  "m22",
+  "m23",
+  "m24",
+  "m31",
+  "m32",
+  "m33",
+  "m34",
+  "m41",
+  "m42",
+  "m43",
+  "m44",
+  "is2D",
+  "isIdentity",
 ]) {
-  const propertyDescriptor = Object.getOwnPropertyDescriptor(DOMMatrix.prototype, propertyName)
-  propertyDescriptor.enumerable = true
-  Object.defineProperty(DOMMatrix.prototype, propertyName, propertyDescriptor)
+  const propertyDescriptor = Object.getOwnPropertyDescriptor(DOMMatrix.prototype, propertyName);
+  propertyDescriptor.enumerable = true;
+  Object.defineProperty(DOMMatrix.prototype, propertyName, propertyDescriptor);
 }
 
-module.exports = { DOMPoint, DOMMatrix, DOMRect }
+module.exports = { DOMPoint, DOMMatrix, DOMRect };

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-const { platform, homedir } = require('os')
-const { join } = require('path')
+const { platform, homedir } = require("node:os");
+const { join } = require("node:path");
 
 const {
   clearAllCache,
@@ -20,148 +20,152 @@ const {
   GifEncoder,
   GifDisposal,
   LottieAnimation,
-} = require('./js-binding')
+} = require("./js-binding");
 
-const { DOMPoint, DOMMatrix, DOMRect } = require('./geometry')
+const { DOMPoint, DOMMatrix, DOMRect } = require("./geometry");
 
-const loadImage = require('./load-image')
+const loadImage = require("./load-image");
 
 // Add Symbol.dispose support for GifEncoder (ECMAScript 2024 Explicit Resource Management)
-if (GifEncoder && typeof Symbol.dispose !== 'undefined') {
+if (GifEncoder && typeof Symbol.dispose !== "undefined") {
   GifEncoder.prototype[Symbol.dispose] = function () {
-    this.dispose()
-  }
+    this.dispose();
+  };
 }
 
 const SvgExportFlag = {
   ConvertTextToPaths: 0x01,
   NoPrettyXML: 0x02,
   RelativePathEncoding: 0x04,
-}
+};
 
-if (!('families' in GlobalFonts)) {
-  Object.defineProperty(GlobalFonts, 'families', {
+if (!("families" in GlobalFonts)) {
+  Object.defineProperty(GlobalFonts, "families", {
     get: function () {
-      return JSON.parse(GlobalFonts.getFamilies().toString())
+      return JSON.parse(GlobalFonts.getFamilies().toString());
     },
-  })
+  });
 }
 
-if (!('has' in GlobalFonts)) {
-  Object.defineProperty(GlobalFonts, 'has', {
+if (!("has" in GlobalFonts)) {
+  Object.defineProperty(GlobalFonts, "has", {
     value: function has(name) {
-      return !!JSON.parse(GlobalFonts.getFamilies().toString()).find(({ family }) => family === name)
+      return !!JSON.parse(GlobalFonts.getFamilies().toString()).find(
+        ({ family }) => family === name,
+      );
     },
     configurable: false,
     enumerable: false,
     writable: false,
-  })
+  });
 }
 
-const _toBlob = CanvasElement.prototype.toBlob
-const _convertToBlob = CanvasElement.prototype.convertToBlob
-if ('Blob' in globalThis) {
+const _toBlob = CanvasElement.prototype.toBlob;
+const _convertToBlob = CanvasElement.prototype.convertToBlob;
+if ("Blob" in globalThis) {
   CanvasElement.prototype.toBlob = function toBlob(callback, mimeType, quality) {
     _toBlob.call(
       this,
       function (/** @type {Uint8Array} */ imageBuffer) {
-        const blob = new Blob([imageBuffer.buffer], { type: mimeType })
-        callback(blob)
+        const blob = new Blob([imageBuffer.buffer], { type: mimeType });
+        callback(blob);
       },
       mimeType,
       quality,
-    )
-  }
+    );
+  };
   CanvasElement.prototype.convertToBlob = function convertToBlob(options) {
     return _convertToBlob.call(this, options).then((/** @type {Uint8Array} */ imageBuffer) => {
-      const blob = new Blob([imageBuffer.buffer], { type: options?.mime || 'image/png' })
-      return blob
-    })
-  }
+      const blob = new Blob([imageBuffer.buffer], { type: options?.mime || "image/png" });
+      return blob;
+    });
+  };
 } else {
   // oxlint-disable-next-line no-unused-vars
   CanvasElement.prototype.toBlob = function toBlob(callback, mimeType, quality) {
-    callback(null)
-  }
+    callback(null);
+  };
   // oxlint-disable-next-line no-unused-vars
   CanvasElement.prototype.convertToBlob = function convertToBlob(options) {
-    return Promise.reject(new Error('Blob is not supported in this environment'))
-  }
+    return Promise.reject(new Error("Blob is not supported in this environment"));
+  };
 }
 
-const _getTransform = CanvasRenderingContext2D.prototype.getTransform
+const _getTransform = CanvasRenderingContext2D.prototype.getTransform;
 
 CanvasRenderingContext2D.prototype.getTransform = function getTransform() {
-  const transform = _getTransform.apply(this, arguments)
+  const transform = _getTransform.apply(this, arguments);
   // monkey patched, skip
   if (transform instanceof DOMMatrix) {
-    return transform
+    return transform;
   }
-  const { a, b, c, d, e, f } = transform
-  return new DOMMatrix([a, b, c, d, e, f])
-}
+  const { a, b, c, d, e, f } = transform;
+  return new DOMMatrix([a, b, c, d, e, f]);
+};
 
 // Workaround for webpack bundling issue with drawImage
 // Store the original drawImage method
-const _drawImage = CanvasRenderingContext2D.prototype.drawImage
+const _drawImage = CanvasRenderingContext2D.prototype.drawImage;
 
 // Override drawImage to ensure proper type recognition in bundled environments
 CanvasRenderingContext2D.prototype.drawImage = function drawImage(image, ...args) {
   // If the image is a Canvas-like object but not recognized due to bundling,
   // we need to ensure it's properly identified
-  if (image && typeof image === 'object') {
+  if (image && typeof image === "object") {
     // First check if it's a wrapped canvas object
     if (image.canvas instanceof CanvasElement || image.canvas instanceof SVGCanvas) {
-      image = image.canvas
+      image = image.canvas;
     } else if (image._canvas instanceof CanvasElement || image._canvas instanceof SVGCanvas) {
-      image = image._canvas
+      image = image._canvas;
     }
     // Then check if it's a Canvas-like object by checking for getContext method
-    else if (typeof image.getContext === 'function' && image.width && image.height) {
+    else if (typeof image.getContext === "function" && image.width && image.height) {
       // If it has canvas properties but isn't recognized as CanvasElement or SVGCanvas,
       // try to correct the prototype chain
       if (!(image instanceof CanvasElement) && !(image instanceof SVGCanvas)) {
         // Try to create a proper CanvasElement from the canvas-like object
         // This helps when webpack has transformed the prototype chain
-        Object.setPrototypeOf(image, CanvasElement.prototype)
+        Object.setPrototypeOf(image, CanvasElement.prototype);
       }
     }
   }
 
   // Call the original drawImage with the potentially corrected image
-  return _drawImage.apply(this, [image, ...args])
-}
+  return _drawImage.apply(this, [image, ...args]);
+};
 
 function createCanvas(width, height, flag) {
-  const isSvgBackend = typeof flag !== 'undefined'
-  return isSvgBackend ? new SVGCanvas(width, height, flag) : new CanvasElement(width, height)
+  const isSvgBackend = typeof flag !== "undefined";
+  return isSvgBackend ? new SVGCanvas(width, height, flag) : new CanvasElement(width, height);
 }
 
 class Canvas {
   constructor(width, height, flag) {
-    return createCanvas(width, height, flag)
+    return createCanvas(width, height, flag);
   }
 
   static [Symbol.hasInstance](instance) {
-    return instance instanceof CanvasElement || instance instanceof SVGCanvas
+    return instance instanceof CanvasElement || instance instanceof SVGCanvas;
   }
 }
 
 if (!process.env.DISABLE_SYSTEM_FONTS_LOAD) {
-  GlobalFonts.loadSystemFonts()
-  const platformName = platform()
-  const homedirPath = homedir()
+  GlobalFonts.loadSystemFonts();
+  const platformName = platform();
+  const homedirPath = homedir();
   switch (platformName) {
-    case 'win32':
-      GlobalFonts.loadFontsFromDir(join(homedirPath, 'AppData', 'Local', 'Microsoft', 'Windows', 'Fonts'))
-      break
-    case 'darwin':
-      GlobalFonts.loadFontsFromDir(join(homedirPath, 'Library', 'Fonts'))
-      break
-    case 'linux':
-      GlobalFonts.loadFontsFromDir(join('usr', 'local', 'share', 'fonts'))
-      GlobalFonts.loadFontsFromDir(join(homedirPath, '.fonts'))
-      break
+    case "win32":
+      GlobalFonts.loadFontsFromDir(
+        join(homedirPath, "AppData", "Local", "Microsoft", "Windows", "Fonts"),
+      );
+      break;
+    case "darwin":
+      GlobalFonts.loadFontsFromDir(join(homedirPath, "Library", "Fonts"));
+      break;
+    case "linux":
+      GlobalFonts.loadFontsFromDir(join("usr", "local", "share", "fonts"));
+      GlobalFonts.loadFontsFromDir(join(homedirPath, ".fonts"));
+      break;
   }
 }
 
@@ -193,4 +197,4 @@ module.exports = {
   GifDisposal,
   // Lottie animation
   LottieAnimation,
-}
+};

--- a/js-binding.js
+++ b/js-binding.js
@@ -75,7 +75,7 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        return require('@napi-rs/canvas-android-arm64')
+        return require('@aphrody-code/canvas-android-arm64')
       } catch (e) {
         loadErrors.push(e)
       }
@@ -86,7 +86,7 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        return require('@napi-rs/canvas-android-arm-eabi')
+        return require('@aphrody-code/canvas-android-arm-eabi')
       } catch (e) {
         loadErrors.push(e)
       }
@@ -105,7 +105,7 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          return require('@napi-rs/canvas-win32-x64-gnu')
+          return require('@aphrody-code/canvas-win32-x64-gnu')
         } catch (e) {
           loadErrors.push(e)
         }
@@ -116,7 +116,7 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          return require('@napi-rs/canvas-win32-x64-msvc')
+          return require('@aphrody-code/canvas-win32-x64-msvc')
         } catch (e) {
           loadErrors.push(e)
         }
@@ -128,7 +128,7 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        return require('@napi-rs/canvas-win32-ia32-msvc')
+        return require('@aphrody-code/canvas-win32-ia32-msvc')
       } catch (e) {
         loadErrors.push(e)
       }
@@ -139,7 +139,7 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        return require('@napi-rs/canvas-win32-arm64-msvc')
+        return require('@aphrody-code/canvas-win32-arm64-msvc')
       } catch (e) {
         loadErrors.push(e)
       }
@@ -153,7 +153,7 @@ function requireNative() {
       loadErrors.push(e)
     }
     try {
-      return require('@napi-rs/canvas-darwin-universal')
+      return require('@aphrody-code/canvas-darwin-universal')
     } catch (e) {
       loadErrors.push(e)
     }
@@ -164,7 +164,7 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        return require('@napi-rs/canvas-darwin-x64')
+        return require('@aphrody-code/canvas-darwin-x64')
       } catch (e) {
         loadErrors.push(e)
       }
@@ -175,7 +175,7 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        return require('@napi-rs/canvas-darwin-arm64')
+        return require('@aphrody-code/canvas-darwin-arm64')
       } catch (e) {
         loadErrors.push(e)
       }
@@ -190,7 +190,7 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        return require('@napi-rs/canvas-freebsd-x64')
+        return require('@aphrody-code/canvas-freebsd-x64')
       } catch (e) {
         loadErrors.push(e)
       }
@@ -201,7 +201,7 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        return require('@napi-rs/canvas-freebsd-arm64')
+        return require('@aphrody-code/canvas-freebsd-arm64')
       } catch (e) {
         loadErrors.push(e)
       }
@@ -217,7 +217,7 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          return require('@napi-rs/canvas-linux-x64-musl')
+          return require('@aphrody-code/canvas-linux-x64-musl')
         } catch (e) {
           loadErrors.push(e)
         }
@@ -228,7 +228,7 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          return require('@napi-rs/canvas-linux-x64-gnu')
+          return require('@aphrody-code/canvas-linux-x64-gnu')
         } catch (e) {
           loadErrors.push(e)
         }
@@ -241,7 +241,7 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          return require('@napi-rs/canvas-linux-arm64-musl')
+          return require('@aphrody-code/canvas-linux-arm64-musl')
         } catch (e) {
           loadErrors.push(e)
         }
@@ -252,7 +252,7 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          return require('@napi-rs/canvas-linux-arm64-gnu')
+          return require('@aphrody-code/canvas-linux-arm64-gnu')
         } catch (e) {
           loadErrors.push(e)
         }
@@ -265,7 +265,7 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          return require('@napi-rs/canvas-linux-arm-musleabihf')
+          return require('@aphrody-code/canvas-linux-arm-musleabihf')
         } catch (e) {
           loadErrors.push(e)
         }
@@ -276,7 +276,7 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          return require('@napi-rs/canvas-linux-arm-gnueabihf')
+          return require('@aphrody-code/canvas-linux-arm-gnueabihf')
         } catch (e) {
           loadErrors.push(e)
         }
@@ -289,7 +289,7 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          return require('@napi-rs/canvas-linux-loong64-musl')
+          return require('@aphrody-code/canvas-linux-loong64-musl')
         } catch (e) {
           loadErrors.push(e)
         }
@@ -300,7 +300,7 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          return require('@napi-rs/canvas-linux-loong64-gnu')
+          return require('@aphrody-code/canvas-linux-loong64-gnu')
         } catch (e) {
           loadErrors.push(e)
         }
@@ -313,7 +313,7 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          return require('@napi-rs/canvas-linux-riscv64-musl')
+          return require('@aphrody-code/canvas-linux-riscv64-musl')
         } catch (e) {
           loadErrors.push(e)
         }
@@ -324,7 +324,7 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          return require('@napi-rs/canvas-linux-riscv64-gnu')
+          return require('@aphrody-code/canvas-linux-riscv64-gnu')
         } catch (e) {
           loadErrors.push(e)
         }
@@ -336,7 +336,7 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        return require('@napi-rs/canvas-linux-ppc64-gnu')
+        return require('@aphrody-code/canvas-linux-ppc64-gnu')
       } catch (e) {
         loadErrors.push(e)
       }
@@ -347,7 +347,7 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        return require('@napi-rs/canvas-linux-s390x-gnu')
+        return require('@aphrody-code/canvas-linux-s390x-gnu')
       } catch (e) {
         loadErrors.push(e)
       }
@@ -362,7 +362,7 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        return require('@napi-rs/canvas-openharmony-arm64')
+        return require('@aphrody-code/canvas-openharmony-arm64')
       } catch (e) {
         loadErrors.push(e)
       }
@@ -373,7 +373,7 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        return require('@napi-rs/canvas-openharmony-x64')
+        return require('@aphrody-code/canvas-openharmony-x64')
       } catch (e) {
         loadErrors.push(e)
       }
@@ -384,7 +384,7 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('@napi-rs/canvas-openharmony-arm')
+        const binding = require('@aphrody-code/canvas-openharmony-arm')
         return binding
       } catch (e) {
         loadErrors.push(e)
@@ -412,7 +412,7 @@ if (!nativeBinding || process.env.NAPI_RS_FORCE_WASI) {
   }
   if (!nativeBinding) {
     try {
-      wasiBinding = require('@napi-rs/canvas-wasm32-wasi')
+      wasiBinding = require('@aphrody-code/canvas-wasm32-wasi')
       nativeBinding = wasiBinding
     } catch (err) {
       if (process.env.NAPI_RS_FORCE_WASI) {

--- a/load-image.js
+++ b/load-image.js
@@ -1,13 +1,13 @@
-const fs = require('fs')
-const { Readable } = require('stream')
-const { URL } = require('url')
+const fs = require("node:fs");
+const { Readable } = require("node:stream");
+const { URL } = require("node:url");
 
-const { Image } = require('./js-binding')
+const { Image } = require("./js-binding");
 
-let http, https
+let http, https;
 
-const MAX_REDIRECTS = 20
-const REDIRECT_STATUSES = new Set([301, 302])
+const MAX_REDIRECTS = 20;
+const REDIRECT_STATUSES = new Set([301, 302]);
 
 /**
  * Loads the given source into canvas Image
@@ -16,76 +16,91 @@ const REDIRECT_STATUSES = new Set([301, 302])
  */
 module.exports = async function loadImage(source, options = {}) {
   // use the same buffer without copying if the source is a buffer
-  if (Buffer.isBuffer(source) || source instanceof Uint8Array) return createImage(source, options.alt)
+  if (Buffer.isBuffer(source) || source instanceof Uint8Array)
+    return createImage(source, options.alt);
   // load readable stream as image
-  if (source instanceof Readable) return createImage(await consumeStream(source), options.alt)
+  if (source instanceof Readable) return createImage(await consumeStream(source), options.alt);
   // construct a Uint8Array if the source is ArrayBuffer or SharedArrayBuffer
   if (source instanceof ArrayBuffer || source instanceof SharedArrayBuffer)
-    return createImage(new Uint8Array(source), options.alt)
+    return createImage(new Uint8Array(source), options.alt);
   // construct a buffer if the source is buffer-like
-  if (isBufferLike(source)) return createImage(Buffer.from(source), options.alt)
+  if (isBufferLike(source)) return createImage(Buffer.from(source), options.alt);
   // if the source is Image instance, copy the image src to new image
-  if (source instanceof Image) return createImage(source.src, options.alt)
+  if (source instanceof Image) return createImage(source.src, options.alt);
   // if source is string and in data uri format, construct image using data uri
-  if (typeof source === 'string' && source.trimStart().startsWith('data:')) {
-    const commaIdx = source.indexOf(',')
-    const encoding = source.lastIndexOf('base64', commaIdx) < 0 ? 'utf-8' : 'base64'
-    const data = Buffer.from(source.slice(commaIdx + 1), encoding)
-    return createImage(data, options.alt)
+  if (typeof source === "string" && source.trimStart().startsWith("data:")) {
+    const commaIdx = source.indexOf(",");
+    const encoding = source.lastIndexOf("base64", commaIdx) < 0 ? "utf-8" : "base64";
+    const data = Buffer.from(source.slice(commaIdx + 1), encoding);
+    return createImage(data, options.alt);
   }
   // if source is a string or URL instance
-  if (typeof source === 'string') {
+  if (typeof source === "string") {
     // if the source exists as a file, construct image from that file
-    if (!source.startsWith('http') && !source.startsWith('https') && (await exists(source))) {
-      return createImage(source, options.alt)
+    if (!source.startsWith("http") && !source.startsWith("https") && (await exists(source))) {
+      return createImage(source, options.alt);
     } else {
       // the source is a remote url here
-      source = new URL(source)
+      source = new URL(source);
       // attempt to download the remote source and construct image
       const data = await new Promise((resolve, reject) =>
         makeRequest(
           source,
           resolve,
           reject,
-          typeof options.maxRedirects === 'number' && options.maxRedirects >= 0 ? options.maxRedirects : MAX_REDIRECTS,
+          typeof options.maxRedirects === "number" && options.maxRedirects >= 0
+            ? options.maxRedirects
+            : MAX_REDIRECTS,
           options.requestOptions,
         ),
-      )
-      return createImage(data, options.alt)
+      );
+      return createImage(data, options.alt);
     }
   }
 
   if (source instanceof URL) {
-    if (source.protocol === 'file:') {
+    if (source.protocol === "file:") {
       // remove the leading slash on windows
-      return createImage(process.platform === 'win32' ? source.pathname.substring(1) : source.pathname, options.alt)
+      return createImage(
+        process.platform === "win32" ? source.pathname.substring(1) : source.pathname,
+        options.alt,
+      );
     } else {
       const data = await new Promise((resolve, reject) =>
         makeRequest(
           source,
           resolve,
           reject,
-          typeof options.maxRedirects === 'number' && options.maxRedirects >= 0 ? options.maxRedirects : MAX_REDIRECTS,
+          typeof options.maxRedirects === "number" && options.maxRedirects >= 0
+            ? options.maxRedirects
+            : MAX_REDIRECTS,
           options.requestOptions,
         ),
-      )
-      return createImage(data, options.alt)
+      );
+      return createImage(data, options.alt);
     }
   }
 
   // throw error as don't support that source
-  throw new TypeError('unsupported image source')
-}
+  throw new TypeError("unsupported image source");
+};
 
 function makeRequest(url, resolve, reject, redirectCount, requestOptions) {
-  const isHttps = url.protocol === 'https:'
+  const isHttps = url.protocol === "https:";
   // lazy load the lib
-  const lib = isHttps ? (!https ? (https = require('https')) : https) : !http ? (http = require('http')) : http
+  const lib = isHttps
+    ? !https
+      ? (https = require("node:https"))
+      : https
+    : !http
+      ? (http = require("node:http"))
+      : http;
 
   lib
     .get(url.toString(), requestOptions || {}, (res) => {
       try {
-        const shouldRedirect = REDIRECT_STATUSES.has(res.statusCode) && typeof res.headers.location === 'string'
+        const shouldRedirect =
+          REDIRECT_STATUSES.has(res.statusCode) && typeof res.headers.location === "string";
         if (shouldRedirect && redirectCount > 0)
           return makeRequest(
             new URL(res.headers.location, url.origin),
@@ -93,53 +108,53 @@ function makeRequest(url, resolve, reject, redirectCount, requestOptions) {
             reject,
             redirectCount - 1,
             requestOptions,
-          )
-        if (typeof res.statusCode === 'number' && (res.statusCode < 200 || res.statusCode >= 300)) {
-          return reject(new Error(`remote source rejected with status code ${res.statusCode}`))
+          );
+        if (typeof res.statusCode === "number" && (res.statusCode < 200 || res.statusCode >= 300)) {
+          return reject(new Error(`remote source rejected with status code ${res.statusCode}`));
         }
 
-        consumeStream(res).then(resolve, reject)
+        consumeStream(res).then(resolve, reject);
       } catch (err) {
-        reject(err)
+        reject(err);
       }
     })
-    .on('error', reject)
+    .on("error", reject);
 }
 
 // use stream/consumers in the future?
 function consumeStream(res) {
   return new Promise((resolve, reject) => {
-    const chunks = []
+    const chunks = [];
 
-    res.on('data', (chunk) => chunks.push(chunk))
-    res.on('end', () => resolve(Buffer.concat(chunks)))
-    res.on('error', reject)
-  })
+    res.on("data", (chunk) => chunks.push(chunk));
+    res.on("end", () => resolve(Buffer.concat(chunks)));
+    res.on("error", reject);
+  });
 }
 
 async function createImage(src, alt) {
-  const image = new Image()
-  if (typeof alt === 'string') image.alt = alt
+  const image = new Image();
+  if (typeof alt === "string") image.alt = alt;
 
   return new Promise((resolve, reject) => {
     image.onload = () => {
       // Wait for bitmap decode before resolving
-      image.decode().then(() => resolve(image), reject)
-    }
-    image.onerror = (e) => reject(e)
-    image.src = src
-  })
+      image.decode().then(() => resolve(image), reject);
+    };
+    image.onerror = (e) => reject(e);
+    image.src = src;
+  });
 }
 
 function isBufferLike(src) {
-  return (src && src.type === 'Buffer') || Array.isArray(src)
+  return (src && src.type === "Buffer") || Array.isArray(src);
 }
 
 async function exists(path) {
   try {
-    await fs.promises.access(path, fs.constants.F_OK)
-    return true
+    await fs.promises.access(path, fs.constants.F_OK);
+    return true;
   } catch {
-    return false
+    return false;
   }
 }

--- a/npm/android-arm64/package.json
+++ b/npm/android-arm64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@napi-rs/canvas-android-arm64",
+  "name": "@aphrody-code/canvas-android-arm64",
   "version": "0.1.99",
   "os": [
     "android"
@@ -30,7 +30,7 @@
     "node": ">= 10"
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
+    "registry": "https://npm.pkg.github.com",
     "access": "public"
   },
   "repository": {

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@napi-rs/canvas-darwin-arm64",
+  "name": "@aphrody-code/canvas-darwin-arm64",
   "version": "0.1.99",
   "os": [
     "darwin"
@@ -30,7 +30,7 @@
     "node": ">= 10"
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
+    "registry": "https://npm.pkg.github.com",
     "access": "public"
   },
   "repository": {

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@napi-rs/canvas-darwin-x64",
+  "name": "@aphrody-code/canvas-darwin-x64",
   "version": "0.1.99",
   "os": [
     "darwin"
@@ -30,7 +30,7 @@
     "node": ">= 10"
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
+    "registry": "https://npm.pkg.github.com",
     "access": "public"
   },
   "repository": {

--- a/npm/linux-arm-gnueabihf/package.json
+++ b/npm/linux-arm-gnueabihf/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@napi-rs/canvas-linux-arm-gnueabihf",
+  "name": "@aphrody-code/canvas-linux-arm-gnueabihf",
   "version": "0.1.99",
   "os": [
     "linux"
@@ -30,7 +30,7 @@
     "node": ">= 10"
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
+    "registry": "https://npm.pkg.github.com",
     "access": "public"
   },
   "repository": {

--- a/npm/linux-arm64-gnu/package.json
+++ b/npm/linux-arm64-gnu/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@napi-rs/canvas-linux-arm64-gnu",
+  "name": "@aphrody-code/canvas-linux-arm64-gnu",
   "version": "0.1.99",
   "os": [
     "linux"
@@ -30,7 +30,7 @@
     "node": ">= 10"
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
+    "registry": "https://npm.pkg.github.com",
     "access": "public"
   },
   "repository": {

--- a/npm/linux-arm64-musl/package.json
+++ b/npm/linux-arm64-musl/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@napi-rs/canvas-linux-arm64-musl",
+  "name": "@aphrody-code/canvas-linux-arm64-musl",
   "version": "0.1.99",
   "os": [
     "linux"
@@ -30,7 +30,7 @@
     "node": ">= 10"
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
+    "registry": "https://npm.pkg.github.com",
     "access": "public"
   },
   "repository": {

--- a/npm/linux-riscv64-gnu/package.json
+++ b/npm/linux-riscv64-gnu/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@napi-rs/canvas-linux-riscv64-gnu",
+  "name": "@aphrody-code/canvas-linux-riscv64-gnu",
   "version": "0.1.99",
   "os": [
     "linux"
@@ -30,7 +30,7 @@
     "node": ">= 10"
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
+    "registry": "https://npm.pkg.github.com",
     "access": "public"
   },
   "repository": {

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@napi-rs/canvas-linux-x64-gnu",
+  "name": "@aphrody-code/canvas-linux-x64-gnu",
   "version": "0.1.99",
   "os": [
     "linux"
@@ -30,7 +30,7 @@
     "node": ">= 10"
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
+    "registry": "https://npm.pkg.github.com",
     "access": "public"
   },
   "repository": {

--- a/npm/linux-x64-musl/package.json
+++ b/npm/linux-x64-musl/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@napi-rs/canvas-linux-x64-musl",
+  "name": "@aphrody-code/canvas-linux-x64-musl",
   "version": "0.1.99",
   "os": [
     "linux"
@@ -30,7 +30,7 @@
     "node": ">= 10"
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
+    "registry": "https://npm.pkg.github.com",
     "access": "public"
   },
   "repository": {

--- a/npm/win32-arm64-msvc/package.json
+++ b/npm/win32-arm64-msvc/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@napi-rs/canvas-win32-arm64-msvc",
+  "name": "@aphrody-code/canvas-win32-arm64-msvc",
   "version": "0.1.99",
   "os": [
     "win32"
@@ -31,7 +31,7 @@
     "node": ">= 10"
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
+    "registry": "https://npm.pkg.github.com",
     "access": "public"
   },
   "repository": {

--- a/npm/win32-x64-msvc/package.json
+++ b/npm/win32-x64-msvc/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@napi-rs/canvas-win32-x64-msvc",
+  "name": "@aphrody-code/canvas-win32-x64-msvc",
   "version": "0.1.99",
   "os": [
     "win32"
@@ -31,7 +31,7 @@
     "node": ">= 10"
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
+    "registry": "https://npm.pkg.github.com",
     "access": "public"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@napi-rs/canvas",
-  "version": "0.1.99",
-  "description": "Canvas for Node.js with skia backend",
+  "name": "@aphrody-code/canvas",
+  "version": "0.1.99-fork.1",
+  "description": "Canvas for Node.js with skia backend (aphrody-code fork — published to GitHub Packages)",
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Brooooooklyn/canvas.git"
+    "url": "git+https://github.com/aphrody-code/canvas.git"
   },
   "workspaces": [
     "e2e/*"
@@ -53,7 +53,7 @@
     "node": ">= 10"
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
+    "registry": "https://npm.pkg.github.com",
     "access": "public"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "bench": "node --import @oxc-node/core/register benchmark/bench.ts",
     "build": "napi build --platform --release --js js-binding.js",
     "build:debug": "napi build --platform --js js-binding.js",
-    "example-lottie": "yarn oxnode ./example/lottie-to-video.ts",
+    "example-lottie": "bun ./example/lottie-to-video.ts",
     "format": "run-p format:source format:rs format:toml",
     "format:rs": "cargo fmt",
     "format:source": "prettier . -w",
@@ -71,7 +71,7 @@
     "postpublish": "pinst --enable",
     "test:ci": "ava -c 1",
     "test": "ava",
-    "e2e": "yarn workspace @napi-rs/canvas-e2e-webpack test",
+    "e2e": "bun --filter @napi-rs/canvas-e2e-webpack test",
     "version": "napi version && conventional-changelog -p angular -i CHANGELOG.md -s && git add ."
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,9 +7,6 @@
     "type": "git",
     "url": "git+https://github.com/aphrody-code/canvas.git"
   },
-  "workspaces": [
-    "e2e/*"
-  ],
   "license": "MIT",
   "keywords": [
     "napi-rs",

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "type": "github",
     "url": "https://github.com/sponsors/Brooooooklyn"
   },
-  "packageManager": "yarn@4.14.1",
+  "packageManager": "bun@1.2.0",
   "dependenciesMeta": {
     "canvas": {
       "built": true

--- a/scripts/build-c++abi.mjs
+++ b/scripts/build-c++abi.mjs
@@ -1,46 +1,23 @@
-import { execSync } from 'node:child_process'
-import { readFileSync } from 'node:fs'
-import { fileURLToPath } from 'node:url'
-import { join } from 'node:path'
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 
-const LLVM_VERSION = readFileSync(join(fileURLToPath(import.meta.url), '..', '..', 'llvm-version'), 'utf-8').trim()
+const LLVM_VERSION = readFileSync(join(import.meta.dir, "..", "llvm-version"), "utf-8").trim();
 
-execSync(`wget https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-${LLVM_VERSION}.zip`, {
-  stdio: 'inherit',
-})
+await $`wget https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-${LLVM_VERSION}.zip`.stdio(
+  "inherit",
+);
 
-execSync(`unzip llvmorg-${LLVM_VERSION}.zip`, {
-  stdio: 'inherit',
-})
+await $`unzip llvmorg-${LLVM_VERSION}.zip`.stdio("inherit");
 
-execSync(`mkdir -p build`, {
-  stdio: 'inherit',
-  cwd: `llvm-project-llvmorg-${LLVM_VERSION}`,
-})
+await $`mkdir -p build`.cwd(`llvm-project-llvmorg-${LLVM_VERSION}`).stdio("inherit");
 
-execSync(
-  `cmake -G Ninja -S runtimes -B build -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind" -DLIBCXX_ENABLE_LOCALIZATION=OFF`,
-  {
-    stdio: 'inherit',
-    cwd: `llvm-project-llvmorg-${LLVM_VERSION}`,
-    env: {
-      ...process.env,
-      CXX: 'clang++',
-      CC: 'clang',
-      CXXFLAGS: '-fPIC',
-    },
-  },
-)
+await $`cmake -G Ninja -S runtimes -B build -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind" -DLIBCXX_ENABLE_LOCALIZATION=OFF`
+  .cwd(`llvm-project-llvmorg-${LLVM_VERSION}`)
+  .env({ ...process.env, CXX: "clang++", CC: "clang", CXXFLAGS: "-fPIC" })
+  .stdio("inherit");
 
-execSync(`ninja -C build cxx cxxabi`, {
-  stdio: 'inherit',
-  cwd: `llvm-project-llvmorg-${LLVM_VERSION}`,
-})
+await $`ninja -C build cxx cxxabi`.cwd(`llvm-project-llvmorg-${LLVM_VERSION}`).stdio("inherit");
 
-execSync(`cp llvm-project-llvmorg-${LLVM_VERSION}/build/lib/libc++abi.a .`, {
-  stdio: 'inherit',
-})
+await $`cp llvm-project-llvmorg-${LLVM_VERSION}/build/lib/libc++abi.a .`.stdio("inherit");
 
-execSync(`cp llvm-project-llvmorg-${LLVM_VERSION}/build/lib/libc++.a .`, {
-  stdio: 'inherit',
-})
+await $`cp llvm-project-llvmorg-${LLVM_VERSION}/build/lib/libc++.a .`.stdio("inherit");

--- a/scripts/build-skia.js
+++ b/scripts/build-skia.js
@@ -1,18 +1,22 @@
-const { execSync } = require('node:child_process')
-const { readFileSync, writeFileSync } = require('node:fs')
-const path = require('node:path')
-const { platform, arch } = require('node:os')
+const { execSync } = require("node:child_process");
+const { readFileSync, writeFileSync } = require("node:fs");
+const path = require("node:path");
+const { platform, arch } = require("node:os");
 
-const PLATFORM_NAME = platform()
-const HOST_ARCH = arch()
+const PLATFORM_NAME = platform();
+const HOST_ARCH = arch();
 const HOST_LIBC =
-  PLATFORM_NAME === 'linux' ? (process.report?.getReport()?.header?.glibcVersionRuntime ? 'glibc' : 'musl') : null
+  PLATFORM_NAME === "linux"
+    ? process.report?.getReport()?.header?.glibcVersionRuntime
+      ? "glibc"
+      : "musl"
+    : null;
 
-const [, , TARGET] = process.argv
+const [, , TARGET] = process.argv;
 
-let TARGET_TRIPLE = ''
-if (TARGET && TARGET.startsWith('--target=')) {
-  TARGET_TRIPLE = TARGET.replace('--target=', '')
+let TARGET_TRIPLE = "";
+if (TARGET && TARGET.startsWith("--target=")) {
+  TARGET_TRIPLE = TARGET.replace("--target=", "");
 }
 
 // Skia m148 (commit e179431b2b, "[pdf] Allow table based font subsetting")
@@ -37,39 +41,39 @@ if (TARGET && TARGET.startsWith('--target=')) {
 // whole instead of subsetted (slightly larger PDFs) and woff/woff2 fonts go
 // through the pre-m148 Type3 fallback. All other targets keep full subsetting.
 const PDF_HARFBUZZ_SUBSET_CRASHING_TARGETS = new Set([
-  'x86_64-pc-windows-msvc',
-  'x86_64-unknown-linux-musl',
-  'aarch64-unknown-linux-musl',
-])
+  "x86_64-pc-windows-msvc",
+  "x86_64-unknown-linux-musl",
+  "aarch64-unknown-linux-musl",
+]);
 // Windows-latest in skia.yaml invokes this script with no --target= flag
 // (native x64 host build), so TARGET_TRIPLE is empty even though the resulting
 // binary is x86_64-pc-windows-msvc and is affected by the crash. Match the
 // native host explicitly in addition to the --target= lookup.
-const IS_NATIVE_WIN_X64 = !TARGET_TRIPLE && PLATFORM_NAME === 'win32' && HOST_ARCH === 'x64'
+const IS_NATIVE_WIN_X64 = !TARGET_TRIPLE && PLATFORM_NAME === "win32" && HOST_ARCH === "x64";
 const PDF_HARFBUZZ_SUBSET_ENABLED =
-  !PDF_HARFBUZZ_SUBSET_CRASHING_TARGETS.has(TARGET_TRIPLE) && !IS_NATIVE_WIN_X64
+  !PDF_HARFBUZZ_SUBSET_CRASHING_TARGETS.has(TARGET_TRIPLE) && !IS_NATIVE_WIN_X64;
 
 function exec(command) {
-  console.info(command)
+  console.info(command);
   execSync(command, {
-    stdio: 'inherit',
-    cwd: path.join(__dirname, '..', 'skia'),
+    stdio: "inherit",
+    cwd: path.join(__dirname, "..", "skia"),
     env: process.env,
-    shell: PLATFORM_NAME === 'win32' ? 'powershell' : 'bash',
-  })
+    shell: PLATFORM_NAME === "win32" ? "powershell" : "bash",
+  });
 }
 
-if (process.env.SKIP_SYNC_SK_DEPS !== 'false' && process.env.SKIP_SYNC_SK_DEPS !== '0') {
-  exec('python ./tools/git-sync-deps')
+if (process.env.SKIP_SYNC_SK_DEPS !== "false" && process.env.SKIP_SYNC_SK_DEPS !== "0") {
+  exec("python ./tools/git-sync-deps");
 }
 
-let CC = PLATFORM_NAME === 'win32' ? '\\"clang-cl\\"' : '"clang"'
-let CXX = PLATFORM_NAME === 'win32' ? '\\"clang-cpp\\"' : '"clang++"'
-let ExtraCflagsCC = ''
-let ExtraSkiaBuildFlag = ''
-let ExtraCflags
-let ExtraLdFlags
-let ExtraAsmFlags
+let CC = PLATFORM_NAME === "win32" ? '\\"clang-cl\\"' : '"clang"';
+let CXX = PLATFORM_NAME === "win32" ? '\\"clang-cpp\\"' : '"clang++"';
+let ExtraCflagsCC = "";
+let ExtraSkiaBuildFlag = "";
+let ExtraCflags;
+let ExtraLdFlags;
+let ExtraAsmFlags;
 
 const GN_ARGS = [
   `is_official_build=true`,
@@ -96,7 +100,7 @@ const GN_ARGS = [
   `skia_use_icu=true`,
   // the libavif would conflict with the Rust libavif, use the Rust library to handle avif images
   `skia_use_libavif=false`,
-  `skia_use_libjxl_decode=${!TARGET_TRIPLE.startsWith('riscv64')}`,
+  `skia_use_libjxl_decode=${!TARGET_TRIPLE.startsWith("riscv64")}`,
   `skia_use_libjpeg_turbo_decode=true`,
   `skia_use_libjpeg_turbo_encode=true`,
   `skia_use_libwebp_decode=true`,
@@ -121,10 +125,10 @@ const GN_ARGS = [
   `skia_enable_fontmgr_android=false`,
   `skunicode_tests_enabled=false`,
   `skia_enable_skshaper_tests=false`,
-]
+];
 
 switch (PLATFORM_NAME) {
-  case 'win32':
+  case "win32":
     ExtraCflagsCC =
       '\\"/std:c++20\\",' +
       '\\"/MT\\",' +
@@ -138,17 +142,17 @@ switch (PLATFORM_NAME) {
       '\\"-DSK_CODEC_DECODES_PNG\\",' +
       '\\"-DSK_ENCODE_JPEG\\",' +
       '\\"-DSK_CODEC_DECODES_JPEG\\",' +
-      '\\"-DSK_SHAPER_HARFBUZZ_AVAILABLE\\"'
-    const clangVersion = findClangWinVersion()
+      '\\"-DSK_SHAPER_HARFBUZZ_AVAILABLE\\"';
+    const clangVersion = findClangWinVersion();
     if (clangVersion) {
-      console.info(`Found clang version: ${clangVersion}`)
-      ExtraSkiaBuildFlag = `clang_win_version=\\"${clangVersion}\\"`
+      console.info(`Found clang version: ${clangVersion}`);
+      ExtraSkiaBuildFlag = `clang_win_version=\\"${clangVersion}\\"`;
     }
-    GN_ARGS.push(`clang_win=\\"C:\\\\Program Files\\\\LLVM\\"`)
-    GN_ARGS.push(`skia_enable_fontmgr_win=false`)
-    break
-  case 'linux':
-  case 'darwin':
+    GN_ARGS.push(`clang_win=\\"C:\\\\Program Files\\\\LLVM\\"`);
+    GN_ARGS.push(`skia_enable_fontmgr_win=false`);
+    break;
+  case "linux":
+  case "darwin":
     ExtraCflagsCC =
       '"-std=c++20",' +
       '"-fno-exceptions",' +
@@ -162,32 +166,33 @@ switch (PLATFORM_NAME) {
       '"-DSK_CODEC_DECODES_PNG",' +
       '"-DSK_ENCODE_JPEG",' +
       '"-DSK_CODEC_DECODES_JPEG",' +
-      '"-DSK_SHAPER_HARFBUZZ_AVAILABLE"'
-    if (PLATFORM_NAME === 'linux' && !TARGET_TRIPLE && HOST_ARCH === 'x64') {
-      if (HOST_LIBC === 'glibc') {
-        ExtraCflagsCC += ',"-stdlib=libc++","-static","-I/usr/lib/llvm-19/include/c++/v1"'
+      '"-DSK_SHAPER_HARFBUZZ_AVAILABLE"';
+    if (PLATFORM_NAME === "linux" && !TARGET_TRIPLE && HOST_ARCH === "x64") {
+      if (HOST_LIBC === "glibc") {
+        ExtraCflagsCC += ',"-stdlib=libc++","-static","-I/usr/lib/llvm-19/include/c++/v1"';
       } else {
-        ExtraCflagsCC += ',"-stdlib=libc++","-static","-I/usr/include/c++/v1","-fPIC","-fno-cxx-exceptions"'
+        ExtraCflagsCC +=
+          ',"-stdlib=libc++","-static","-I/usr/include/c++/v1","-fPIC","-fno-cxx-exceptions"';
       }
     }
-    if (PLATFORM_NAME === 'linux' && (!TARGET_TRIPLE || TARGET_TRIPLE.startsWith('x86_64'))) {
-      ExtraCflagsCC += ',"-Wno-psabi"'
+    if (PLATFORM_NAME === "linux" && (!TARGET_TRIPLE || TARGET_TRIPLE.startsWith("x86_64"))) {
+      ExtraCflagsCC += ',"-Wno-psabi"';
     }
-    break
+    break;
   default:
-    throw new TypeError(`Don't support ${PLATFORM_NAME} for now`)
+    throw new TypeError(`Don't support ${PLATFORM_NAME} for now`);
 }
 
 switch (TARGET_TRIPLE) {
-  case 'aarch64-unknown-linux-gnu':
-    ExtraSkiaBuildFlag += ' target_cpu="arm64" target_os="linux"'
+  case "aarch64-unknown-linux-gnu":
+    ExtraSkiaBuildFlag += ' target_cpu="arm64" target_os="linux"';
     ExtraCflags =
-      '"--target=aarch64-unknown-linux-gnu", "--sysroot=/usr/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot", "-I/usr/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot/usr/include", "-march=armv8-a"'
+      '"--target=aarch64-unknown-linux-gnu", "--sysroot=/usr/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot", "-I/usr/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot/usr/include", "-march=armv8-a"';
     ExtraCflagsCC +=
-      ', "--target=aarch64-unknown-linux-gnu", "--sysroot=/usr/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot", "-I/usr/lib/llvm-19/include/c++/v1", "-I/usr/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot/usr/include", "-march=armv8-a"'
+      ', "--target=aarch64-unknown-linux-gnu", "--sysroot=/usr/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot", "-I/usr/lib/llvm-19/include/c++/v1", "-I/usr/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot/usr/include", "-march=armv8-a"';
     ExtraLdFlags =
-      '"-fuse-ld=lld", "-L/usr/aarch64-unknown-linux-gnu/lib/llvm-19/lib", "-L/usr/aarch64-unknown-linux-gnu/lib", "-L/usr/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot/lib", "-L/usr/aarch64-unknown-linux-gnu/lib/gcc/aarch64-unknown-linux-gnu/4.8.5"'
-    ExtraAsmFlags = '"--target=aarch64-unknown-linux-gnu", "-march=armv8-a"'
+      '"-fuse-ld=lld", "-L/usr/aarch64-unknown-linux-gnu/lib/llvm-19/lib", "-L/usr/aarch64-unknown-linux-gnu/lib", "-L/usr/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot/lib", "-L/usr/aarch64-unknown-linux-gnu/lib/gcc/aarch64-unknown-linux-gnu/4.8.5"';
+    ExtraAsmFlags = '"--target=aarch64-unknown-linux-gnu", "-march=armv8-a"';
 
     GN_ARGS.push(
       `extra_ldflags=[${ExtraLdFlags}]`,
@@ -195,161 +200,168 @@ switch (TARGET_TRIPLE) {
       `extra_asmflags=[${ExtraAsmFlags}]`,
       `extra_cflags=[${ExtraCflags}]`,
       `extra_cflags_c=[${ExtraCflags}]`,
-    )
-    break
-  case 'aarch64-unknown-linux-musl':
-    CC = '"zig cc"'
-    CXX = '"zig c++"'
-    ExtraSkiaBuildFlag += ' target_cpu="arm64" target_os="linux"'
-    ExtraCflags = `"--target=aarch64-linux-musl", "-fPIC", "-march=cortex_a78"`
-    ExtraCflagsCC += `, "--target=aarch64-linux-musl", "-static", "-fPIC", "-march=cortex_a78"`
-    ExtraLdFlags = `"--target=aarch64-linux-musl"`
-    ExtraAsmFlags = '"--target=aarch64-linux-musl", "-march=cortex_a78"'
+    );
+    break;
+  case "aarch64-unknown-linux-musl":
+    CC = '"zig cc"';
+    CXX = '"zig c++"';
+    ExtraSkiaBuildFlag += ' target_cpu="arm64" target_os="linux"';
+    ExtraCflags = `"--target=aarch64-linux-musl", "-fPIC", "-march=cortex_a78"`;
+    ExtraCflagsCC += `, "--target=aarch64-linux-musl", "-static", "-fPIC", "-march=cortex_a78"`;
+    ExtraLdFlags = `"--target=aarch64-linux-musl"`;
+    ExtraAsmFlags = '"--target=aarch64-linux-musl", "-march=cortex_a78"';
     GN_ARGS.push(
       `extra_ldflags=[${ExtraLdFlags}]`,
       `ar="zig ar"`,
       `extra_asmflags=[${ExtraAsmFlags}]`,
       `extra_cflags=[${ExtraCflags}]`,
       `extra_cflags_c=[${ExtraCflags}]`,
-    )
-    break
-  case 'x86_64-unknown-linux-musl':
-    CC = '"zig cc"'
-    CXX = '"zig c++"'
-    ExtraSkiaBuildFlag += ' target_cpu="x64" target_os="linux"'
-    ExtraCflags = `"--target=x86_64-linux-musl", "-fPIC"`
-    ExtraCflagsCC += `, "--target=x86_64-linux-musl", "-static", "-fPIC", "-march=sandybridge", "-mevex512"`
-    ExtraLdFlags = `"--target=x86_64-linux-musl"`
-    ExtraAsmFlags = '"--target=x86_64-linux-musl"'
+    );
+    break;
+  case "x86_64-unknown-linux-musl":
+    CC = '"zig cc"';
+    CXX = '"zig c++"';
+    ExtraSkiaBuildFlag += ' target_cpu="x64" target_os="linux"';
+    ExtraCflags = `"--target=x86_64-linux-musl", "-fPIC"`;
+    ExtraCflagsCC += `, "--target=x86_64-linux-musl", "-static", "-fPIC", "-march=sandybridge", "-mevex512"`;
+    ExtraLdFlags = `"--target=x86_64-linux-musl"`;
+    ExtraAsmFlags = '"--target=x86_64-linux-musl"';
     GN_ARGS.push(
       `extra_ldflags=[${ExtraLdFlags}]`,
       `ar="zig ar"`,
       `extra_asmflags=[${ExtraAsmFlags}]`,
       `extra_cflags=[${ExtraCflags}]`,
       `extra_cflags_c=[${ExtraCflags}]`,
-    )
-    break
-  case 'armv7-unknown-linux-gnueabihf':
-    CC = '"arm-linux-gnueabihf-gcc"'
-    CXX = '"arm-linux-gnueabihf-g++"'
+    );
+    break;
+  case "armv7-unknown-linux-gnueabihf":
+    CC = '"arm-linux-gnueabihf-gcc"';
+    CXX = '"arm-linux-gnueabihf-g++"';
     // Disable SkPathData backend - it has issues on 32-bit ARM under QEMU emulation
     // The kill switch was added in Chrome m144: skia commit 7f325708d2
-    ExtraCflagsCC += ',"-DSK_DISABLE_PATHDATA"'
+    ExtraCflagsCC += ',"-DSK_DISABLE_PATHDATA"';
     // Use "armv7a" (not "arm") to avoid Skia's zlib bug where ARM CRC32
     // (armv8-only) is incorrectly enabled for all ARM targets
-    ExtraSkiaBuildFlag += ' target_cpu="armv7a" target_os="linux"'
-    break
-  case 'aarch64-apple-darwin':
-    ExtraSkiaBuildFlag += ' target_cpu="arm64" target_os="mac"'
-    ExtraCflagsCC += ', "--target=arm64-apple-macos", "-mmacosx-version-min=11.0"'
-    ExtraLdFlags = '"--target=arm64-apple-macos", "-mmacosx-version-min=11.0"'
-    ExtraAsmFlags = '"--target=arm64-apple-macos", "-mmacosx-version-min=11.0"'
-    ExtraCflags = '"--target=arm64-apple-macos", "-mmacosx-version-min=11.0"'
+    ExtraSkiaBuildFlag += ' target_cpu="armv7a" target_os="linux"';
+    break;
+  case "aarch64-apple-darwin":
+    ExtraSkiaBuildFlag += ' target_cpu="arm64" target_os="mac"';
+    ExtraCflagsCC += ', "--target=arm64-apple-macos", "-mmacosx-version-min=11.0"';
+    ExtraLdFlags = '"--target=arm64-apple-macos", "-mmacosx-version-min=11.0"';
+    ExtraAsmFlags = '"--target=arm64-apple-macos", "-mmacosx-version-min=11.0"';
+    ExtraCflags = '"--target=arm64-apple-macos", "-mmacosx-version-min=11.0"';
     GN_ARGS.push(
       `extra_ldflags=[${ExtraLdFlags}]`,
       `extra_asmflags=[${ExtraAsmFlags}]`,
       `extra_cflags=[${ExtraCflags}]`,
       `extra_cflags_c=[${ExtraCflags}]`,
-    )
-    break
-  case 'aarch64-linux-android':
-    const { ANDROID_NDK_LATEST_HOME } = process.env
+    );
+    break;
+  case "aarch64-linux-android":
+    const { ANDROID_NDK_LATEST_HOME } = process.env;
     if (!ANDROID_NDK_LATEST_HOME) {
-      throw new TypeError('ANDROID_NDK_LATEST_HOME must be specified in env variable')
+      throw new TypeError("ANDROID_NDK_LATEST_HOME must be specified in env variable");
     }
-    ExtraSkiaBuildFlag += ` target_cpu="arm64" ndk="${ANDROID_NDK_LATEST_HOME}"`
-    break
-  case 'x86_64-apple-darwin':
-    if (HOST_ARCH === 'arm64') {
-      ExtraSkiaBuildFlag += ' target_cpu="x64" target_os="mac"'
-      ExtraCflagsCC += ',"-Wno-psabi"'
+    ExtraSkiaBuildFlag += ` target_cpu="arm64" ndk="${ANDROID_NDK_LATEST_HOME}"`;
+    break;
+  case "x86_64-apple-darwin":
+    if (HOST_ARCH === "arm64") {
+      ExtraSkiaBuildFlag += ' target_cpu="x64" target_os="mac"';
+      ExtraCflagsCC += ',"-Wno-psabi"';
     }
-    ExtraCflagsCC += ', "-mmacosx-version-min=10.13"'
-    ExtraLdFlags = ' "-mmacosx-version-min=10.13"'
-    ExtraAsmFlags = '"-mmacosx-version-min=10.13"'
-    ExtraCflags = '"-mmacosx-version-min=10.13"'
+    ExtraCflagsCC += ', "-mmacosx-version-min=10.13"';
+    ExtraLdFlags = ' "-mmacosx-version-min=10.13"';
+    ExtraAsmFlags = '"-mmacosx-version-min=10.13"';
+    ExtraCflags = '"-mmacosx-version-min=10.13"';
     GN_ARGS.push(
       `extra_ldflags=[${ExtraLdFlags}]`,
       `extra_asmflags=[${ExtraAsmFlags}]`,
       `extra_cflags=[${ExtraCflags}]`,
       `extra_cflags_c=[${ExtraCflags}]`,
-    )
-    break
-  case 'riscv64gc-unknown-linux-gnu':
-    ExtraSkiaBuildFlag += ' target_cpu="riscv64" target_os="linux"'
-    CC = '"riscv64-linux-gnu-gcc"'
-    CXX = '"riscv64-linux-gnu-g++"'
-    break
-  case 'aarch64-pc-windows-msvc':
-    ExtraSkiaBuildFlag += ' target_cpu=\\"arm64\\"'
-    break
-  case '':
-    break
+    );
+    break;
+  case "riscv64gc-unknown-linux-gnu":
+    ExtraSkiaBuildFlag += ' target_cpu="riscv64" target_os="linux"';
+    CC = '"riscv64-linux-gnu-gcc"';
+    CXX = '"riscv64-linux-gnu-g++"';
+    break;
+  case "aarch64-pc-windows-msvc":
+    ExtraSkiaBuildFlag += ' target_cpu=\\"arm64\\"';
+    break;
+  case "":
+    break;
   default:
-    throw new TypeError(`[${TARGET_TRIPLE}] is not a valid target`)
+    throw new TypeError(`[${TARGET_TRIPLE}] is not a valid target`);
 }
 
-const OUTPUT_PATH = path.join('out', 'Static')
+const OUTPUT_PATH = path.join("out", "Static");
 
-GN_ARGS.push(`cc=${CC}`, `cxx=${CXX}`, `extra_cflags_cc=[${ExtraCflagsCC}]`, ExtraSkiaBuildFlag)
+GN_ARGS.push(`cc=${CC}`, `cxx=${CXX}`, `extra_cflags_cc=[${ExtraCflagsCC}]`, ExtraSkiaBuildFlag);
 
-const SkLoadICUCppFilePath = path.join(__dirname, '..', 'skia', 'third_party', 'icu', 'SkLoadICU.cpp')
-const CODE_TO_PATCH = 'good = load_from(executable_directory()) || load_from(library_directory());'
-const CODE_I_WANT = 'good = load_from(library_directory()) || load_from(executable_directory());'
-const GNConfigPath = path.join(__dirname, '..', 'skia', 'BUILD.gn')
+const SkLoadICUCppFilePath = path.join(
+  __dirname,
+  "..",
+  "skia",
+  "third_party",
+  "icu",
+  "SkLoadICU.cpp",
+);
+const CODE_TO_PATCH = "good = load_from(executable_directory()) || load_from(library_directory());";
+const CODE_I_WANT = "good = load_from(library_directory()) || load_from(executable_directory());";
+const GNConfigPath = path.join(__dirname, "..", "skia", "BUILD.gn");
 const GNExampleCode = `skia_executable("skia_c_api_example") {
   sources = [ "experimental/c-api-example/skia-c-example.c" ]
   include_dirs = [ "." ]
   deps = [ ":skia" ]
-}`
+}`;
 
-if (PLATFORM_NAME === 'win32') {
-  const content = readFileSync(SkLoadICUCppFilePath, 'utf8')
-  const patch = content.replace(CODE_TO_PATCH, CODE_I_WANT)
-  writeFileSync(SkLoadICUCppFilePath, patch)
-  process.once('beforeExit', () => {
-    writeFileSync(SkLoadICUCppFilePath, content)
-  })
+if (PLATFORM_NAME === "win32") {
+  const content = readFileSync(SkLoadICUCppFilePath, "utf8");
+  const patch = content.replace(CODE_TO_PATCH, CODE_I_WANT);
+  writeFileSync(SkLoadICUCppFilePath, patch);
+  process.once("beforeExit", () => {
+    writeFileSync(SkLoadICUCppFilePath, content);
+  });
 }
 
-const GN_BUILD_CONTENT = readFileSync(GNConfigPath, 'utf8')
-writeFileSync(GNConfigPath, GN_BUILD_CONTENT.replace(GNExampleCode, ''))
+const GN_BUILD_CONTENT = readFileSync(GNConfigPath, "utf8");
+writeFileSync(GNConfigPath, GN_BUILD_CONTENT.replace(GNExampleCode, ""));
 
-process.once('beforeExit', () => {
-  writeFileSync(GNConfigPath, GN_BUILD_CONTENT)
-})
+process.once("beforeExit", () => {
+  writeFileSync(GNConfigPath, GN_BUILD_CONTENT);
+});
 
 exec(
-  `${process.env.GN_EXE ? process.env.GN_EXE : path.join('bin', 'gn')} gen ${OUTPUT_PATH} --args='${GN_ARGS.join(
-    ' ',
+  `${process.env.GN_EXE ? process.env.GN_EXE : path.join("bin", "gn")} gen ${OUTPUT_PATH} --args='${GN_ARGS.join(
+    " ",
   )}'`,
-)
+);
 
 // linux musl
 // don't know why generated: python3 ../../third_party/externals/icu/scripts/make_data_assembly.py ../../third_party/externals/icu/common/icudtl.dat gen/third_party/icu/icudtl_dat.S
 // `python3` should be `python`
 if (process.env.GN_EXE) {
-  const { readFileSync, writeFileSync } = require('fs')
-  const { join } = require('path')
+  const { readFileSync, writeFileSync } = require("node:fs");
+  const { join } = require("node:path");
 
-  const ninjaToolchain = join(__dirname, '..', 'skia', 'out', 'Static', 'toolchain.ninja')
-  const ninjaToolchainContent = readFileSync(ninjaToolchain, 'utf8')
-  writeFileSync(ninjaToolchain, ninjaToolchainContent.replace('python3', 'python'))
+  const ninjaToolchain = join(__dirname, "..", "skia", "out", "Static", "toolchain.ninja");
+  const ninjaToolchainContent = readFileSync(ninjaToolchain, "utf8");
+  writeFileSync(ninjaToolchain, ninjaToolchainContent.replace("python3", "python"));
 }
 
-console.time('Build Skia')
+console.time("Build Skia");
 
-exec(`ninja -C ${OUTPUT_PATH}`)
+exec(`ninja -C ${OUTPUT_PATH}`);
 
-console.timeEnd('Build Skia')
+console.timeEnd("Build Skia");
 
 function findClangWinVersion() {
-  const stdout = execSync('clang --version', {
-    encoding: 'utf8',
-  })
-  const clangVersion = stdout.match(/clang version\s(\d+\.\d+\.\d+)/)
+  const stdout = execSync("clang --version", {
+    encoding: "utf8",
+  });
+  const clangVersion = stdout.match(/clang version\s(\d+\.\d+\.\d+)/);
   if (!clangVersion) {
-    return null
+    return null;
   }
-  return clangVersion[1]?.split('.')?.at(0)
+  return clangVersion[1]?.split(".")?.at(0);
 }

--- a/scripts/debug-memory.mjs
+++ b/scripts/debug-memory.mjs
@@ -1,65 +1,69 @@
-import { createRequire } from 'node:module'
-import { setTimeout } from 'node:timers/promises'
+import { createRequire } from "node:module";
+import { setTimeout } from "node:timers/promises";
 
-import { whiteBright, red, green, gray } from 'colorette'
-import prettyBytes from 'pretty-bytes'
-import { table } from 'table'
+import prettyBytes from "pretty-bytes";
+import { table } from "table";
 
-import { createCanvas, Path2D, clearAllCache } from '../index.js'
+const whiteBright = (s) => `\x1b[97m${s}\x1b[0m`;
+const red = (s) => `\x1b[31m${s}\x1b[0m`;
+const green = (s) => `\x1b[32m${s}\x1b[0m`;
+const gray = (s) => `\x1b[90m${s}\x1b[0m`;
+
+import { createCanvas, Path2D, clearAllCache } from "../index.js";
 
 function paint() {
-  const require = createRequire(import.meta.url)
-  const tiger = require('../example/tiger.json')
-  const canvas = createCanvas(6016, 3384)
-  const ctx = canvas.getContext('2d')
+  const require = createRequire(import.meta.url);
+  const tiger = require("../example/tiger.json");
+  const canvas = createCanvas(6016, 3384);
+  const ctx = canvas.getContext("2d");
   for (const pathObject of tiger) {
-    const p = new Path2D(pathObject.d)
-    ctx.fillStyle = pathObject.fillStyle
-    ctx.strokeStyle = pathObject.strokeStyle
+    const p = new Path2D(pathObject.d);
+    ctx.fillStyle = pathObject.fillStyle;
+    ctx.strokeStyle = pathObject.strokeStyle;
     if (pathObject.lineWidth) {
-      ctx.lineWidth = parseInt(pathObject.lineWidth, 10)
+      ctx.lineWidth = parseInt(pathObject.lineWidth, 10);
     }
-    ctx.stroke(p)
-    ctx.fill(p)
+    ctx.stroke(p);
+    ctx.fill(p);
   }
 }
 
-const initial = process.memoryUsage()
+const initial = process.memoryUsage();
 
 async function main() {
   for (const _ of Array.from({ length: 100 })) {
-    displayMemoryUsageFromNode(initial)
-    await setTimeout(100)
-    global?.gc?.()
-    await paint()
+    displayMemoryUsageFromNode(initial);
+    await setTimeout(100);
+    global?.gc?.();
+    await paint();
   }
 }
 
 main().then(() => {
-  displayMemoryUsageFromNode(initial)
-  clearAllCache()
-  global?.gc?.()
+  displayMemoryUsageFromNode(initial);
+  clearAllCache();
+  global?.gc?.();
   setInterval(() => {
-    displayMemoryUsageFromNode(initial)
-  }, 2000)
-})
+    displayMemoryUsageFromNode(initial);
+  }, 2000);
+});
 
 function displayMemoryUsageFromNode(initialMemoryUsage) {
-  const finalMemoryUsage = process.memoryUsage()
-  const titles = Object.keys(initialMemoryUsage).map((k) => whiteBright(k))
-  const tableData = [titles]
-  const diffColumn = []
+  const finalMemoryUsage = process.memoryUsage();
+  const titles = Object.keys(initialMemoryUsage).map((k) => whiteBright(k));
+  const tableData = [titles];
+  const diffColumn = [];
   for (const [key, value] of Object.entries(initialMemoryUsage)) {
-    const diff = finalMemoryUsage[key] - value
-    const prettyDiff = prettyBytes(diff, { signed: true })
+    const diff = finalMemoryUsage[key] - value;
+    const prettyDiff = prettyBytes(diff, { signed: true });
     if (diff > 0) {
-      diffColumn.push(red(prettyDiff))
+      diffColumn.push(red(prettyDiff));
     } else if (diff < 0) {
-      diffColumn.push(green(prettyDiff))
+      diffColumn.push(green(prettyDiff));
     } else {
-      diffColumn.push(gray(prettyDiff))
+      diffColumn.push(gray(prettyDiff));
     }
   }
-  tableData.push(diffColumn)
-  console.info(table(tableData))
+  tableData.push(diffColumn);
+  console.info(table(tableData));
 }

--- a/scripts/release-skia-binary.mjs
+++ b/scripts/release-skia-binary.mjs
@@ -1,161 +1,178 @@
-import { execSync } from 'node:child_process'
-import { promises as fs, copyFileSync, statSync } from 'node:fs'
-import { platform } from 'node:os'
-import { parse, join } from 'node:path'
+import { promises as fs, copyFileSync, statSync } from "node:fs";
+import { platform } from "node:os";
+import { parse, join } from "node:path";
 
-import { Octokit } from '@octokit/rest'
-import { green } from 'colorette'
+import { Octokit } from "@octokit/rest";
 
-import { libPath, TAG, OWNER, REPO, dirname } from './utils.mjs'
+import { libPath, TAG, OWNER, REPO, dirname } from "./utils.mjs";
 
-const PLATFORM_NAME = platform()
+const green = (s) => `\x1b[32m${s}\x1b[0m`;
 
-const [, , ARG, TARGET] = process.argv
+const PLATFORM_NAME = platform();
 
-let TARGET_TRIPLE
+const [, , ARG, TARGET] = process.argv;
 
-if (TARGET && TARGET.startsWith('--target=')) {
-  TARGET_TRIPLE = TARGET.replace('--target=', '')
+let TARGET_TRIPLE;
+
+if (TARGET && TARGET.startsWith("--target=")) {
+  TARGET_TRIPLE = TARGET.replace("--target=", "");
 }
 
-const LIB = ['skia', 'skparagraph', 'skshaper', 'svg', 'skunicode_core', 'skunicode_icu', 'skottie', 'skresources', 'sksg', 'jsonreader']
-const ICU_DAT = 'icudtl.dat'
+const LIB = [
+  "skia",
+  "skparagraph",
+  "skshaper",
+  "svg",
+  "skunicode_core",
+  "skunicode_icu",
+  "skottie",
+  "skresources",
+  "sksg",
+  "jsonreader",
+];
+const ICU_DAT = "icudtl.dat";
 
 const CLIENT = new Octokit({
   auth: process.env.GITHUB_TOKEN,
-})
+});
 
 async function upload() {
-  let release_id
-  let assets = []
+  let release_id;
+  let assets = [];
   try {
-    console.info(green(`Fetching release by tag: [${TAG}]`))
+    console.info(green(`Fetching release by tag: [${TAG}]`));
     const release = await CLIENT.repos.getReleaseByTag({
       repo: REPO,
       owner: OWNER,
       tag: TAG,
-    })
-    release_id = release.data.id
-    assets = release.data.assets
+    });
+    release_id = release.data.id;
+    assets = release.data.assets;
   } catch (e) {
     if (e.status === 404) {
-      console.info(green(`No release tag, creating release tag ${TAG}`))
+      console.info(green(`No release tag, creating release tag ${TAG}`));
       const release = await CLIENT.repos.createRelease({
         repo: REPO,
         owner: OWNER,
         tag_name: TAG,
         name: TAG,
-      })
-      release_id = release.data.id
+      });
+      release_id = release.data.id;
     } else {
-      throw e
+      throw e;
     }
   }
   for (const lib of LIB) {
-    const { copy, binary, filename } = libPath(lib, PLATFORM_NAME, TARGET_TRIPLE)
-    console.info(green(`Copy [${binary}] to [${copy}]`))
-    await fs.copyFile(binary, copy)
-    console.info(green(`Uploading [${copy}] to github release: [${TAG}]`))
+    const { copy, binary, filename } = libPath(lib, PLATFORM_NAME, TARGET_TRIPLE);
+    console.info(green(`Copy [${binary}] to [${copy}]`));
+    await fs.copyFile(binary, copy);
+    console.info(green(`Uploading [${copy}] to github release: [${TAG}]`));
 
-    const asset = assets.find(({ name }) => name === parse(copy).base)
+    const asset = assets.find(({ name }) => name === parse(copy).base);
     if (asset) {
-      console.info(green(`[${copy}] existed, delete it...`))
+      console.info(green(`[${copy}] existed, delete it...`));
       await CLIENT.repos.deleteReleaseAsset({
         owner: OWNER,
         repo: REPO,
         asset_id: asset.id,
-      })
+      });
     }
-    const dstFileStats = statSync(copy)
+    const dstFileStats = statSync(copy);
     await CLIENT.repos
       .uploadReleaseAsset({
         owner: OWNER,
         repo: REPO,
         name: filename,
         release_id,
-        mediaType: { format: 'raw' },
+        mediaType: { format: "raw" },
         headers: {
-          'content-length': dstFileStats.size,
-          'content-type': 'application/octet-stream',
+          "content-length": dstFileStats.size,
+          "content-type": "application/octet-stream",
         },
         data: await fs.readFile(copy),
       })
-      .catch((e) => {
-        execSync(`ls -la ./skia/out/Static`, { stdio: 'inherit' })
-        execSync(`ls -la .`, { stdio: 'inherit' })
-        throw e
-      })
+      .catch(async (e) => {
+        await $`ls -la ./skia/out/Static`.stdio("inherit");
+        await $`ls -la .`.stdio("inherit");
+        throw e;
+      });
   }
-  if (PLATFORM_NAME === 'win32') {
-    const icudtl = assets.find(({ name }) => name === ICU_DAT)
+  if (PLATFORM_NAME === "win32") {
+    const icudtl = assets.find(({ name }) => name === ICU_DAT);
     if (icudtl) {
-      console.info(green(`[${ICU_DAT}] existed, delete it...`))
+      console.info(green(`[${ICU_DAT}] existed, delete it...`));
       await CLIENT.repos.deleteReleaseAsset({
         owner: OWNER,
         repo: REPO,
         asset_id: icudtl.id,
-      })
+      });
     }
-    console.info(green(`Uploading [${ICU_DAT}] to github release: [${TAG}]`))
-    const icuDataPath = join(dirname, '..', 'skia', 'out', 'Static', ICU_DAT)
+    console.info(green(`Uploading [${ICU_DAT}] to github release: [${TAG}]`));
+    const icuDataPath = join(dirname, "..", "skia", "out", "Static", ICU_DAT);
     await CLIENT.repos.uploadReleaseAsset({
       owner: OWNER,
       repo: REPO,
       name: ICU_DAT,
       release_id,
-      mediaType: { format: 'raw' },
+      mediaType: { format: "raw" },
       headers: {
-        'content-length': statSync(icuDataPath).size,
-        'content-type': 'application/octet-stream',
+        "content-length": statSync(icuDataPath).size,
+        "content-type": "application/octet-stream",
       },
       data: await fs.readFile(icuDataPath),
-    })
+    });
   }
 }
 
 async function download() {
-  await fs.mkdir(parse(libPath('skia', PLATFORM_NAME, TARGET_TRIPLE).binary).dir, {
+  await fs.mkdir(parse(libPath("skia", PLATFORM_NAME, TARGET_TRIPLE).binary).dir, {
     recursive: true,
-  })
+  });
   for (const lib of LIB) {
-    const { downloadUrl, binary } = libPath(lib, PLATFORM_NAME, TARGET_TRIPLE)
-    console.info(`downloading ${downloadUrl} to ${binary}`)
-    execSync(`curl -J -L -H "Accept: application/octet-stream" ${downloadUrl} -o ${binary}`, {
-      stdio: 'inherit',
-    })
+    const { downloadUrl, binary } = libPath(lib, PLATFORM_NAME, TARGET_TRIPLE);
+    console.info(`downloading ${downloadUrl} to ${binary}`);
+    await $`curl -J -L -H "Accept: application/octet-stream" ${downloadUrl} -o ${binary}`.stdio(
+      "inherit",
+    );
   }
-  if (PLATFORM_NAME === 'win32') {
-    await downloadIcu()
-    await fs.copyFile(join(dirname, '..', ICU_DAT), join(dirname, '..', 'npm', 'win32-x64-msvc', ICU_DAT))
+  if (PLATFORM_NAME === "win32") {
+    await downloadIcu();
+    await fs.copyFile(
+      join(dirname, "..", ICU_DAT),
+      join(dirname, "..", "npm", "win32-x64-msvc", ICU_DAT),
+    );
   }
 }
 
 function downloadIcu() {
-  const downloadUrl = `https://github.com/${OWNER}/${REPO}/releases/download/${TAG}/${ICU_DAT}`
-  execSync(`curl -J -L -H "Accept: application/octet-stream" ${downloadUrl} -o ${ICU_DAT}`, {
-    stdio: 'inherit',
-  })
-  copyFileSync(join(dirname, '..', ICU_DAT), join(dirname, '..', 'npm', 'win32-x64-msvc', ICU_DAT))
-  return Promise.resolve(null)
+  const downloadUrl = `https://github.com/${OWNER}/${REPO}/releases/download/${TAG}/${ICU_DAT}`;
+  Bun.spawnSync(
+    ["curl", "-J", "-L", "-H", "Accept: application/octet-stream", downloadUrl, "-o", ICU_DAT],
+    {
+      stdio: ["inherit", "inherit", "inherit"],
+    },
+  );
+  copyFileSync(join(dirname, "..", ICU_DAT), join(dirname, "..", "npm", "win32-x64-msvc", ICU_DAT));
+  return Promise.resolve(null);
 }
 
 let program = () => {
-  throw new TypeError(`Unknown arguments [${ARG}]`)
-}
+  throw new TypeError(`Unknown arguments [${ARG}]`);
+};
 
 switch (ARG) {
-  case '--download':
-    program = download
-    break
-  case '--upload':
-    program = upload
-    break
-  case '--download-icu':
-    program = downloadIcu
+  case "--download":
+    program = download;
+    break;
+  case "--upload":
+    program = upload;
+    break;
+  case "--download-icu":
+    program = downloadIcu;
 }
 
 // eslint-disable-next-line sonarjs/no-use-of-empty-return-value
 program().catch((e) => {
-  console.error(e)
-  process.exit(1)
-})
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -1,18 +1,18 @@
-import { execSync } from 'node:child_process'
-import { join } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from "node:path";
 
-export const OWNER = 'Brooooooklyn'
-export const REPO = 'canvas'
+export const OWNER = "Brooooooklyn";
+export const REPO = "canvas";
 
 const [FULL_HASH] =
-  process.env.NODE_ENV === 'ava' ? ['000000'] : execSync(`git submodule status skia`).toString('utf8').trim().split(' ')
+  process.env.NODE_ENV === "ava"
+    ? ["000000"]
+    : (await $`git submodule status skia`.text()).trim().split(" ");
 
-const SHORT_HASH = FULL_HASH.substring(0, 8)
+const SHORT_HASH = FULL_HASH.substring(0, 8);
 
-export const dirname = join(fileURLToPath(import.meta.url), '..')
+export const dirname = import.meta.dir;
 
-export const TAG = `skia-${SHORT_HASH}`
+export const TAG = `skia-${SHORT_HASH}`;
 
 /**
  * @param {string} lib Static lib name
@@ -21,54 +21,61 @@ export const TAG = `skia-${SHORT_HASH}`
  * @returns {{ binary: string; copy: string; downloadUrl: string; filename: string }}
  */
 export function libPath(lib, hostPlatform, triple, tag = TAG) {
-  let platformName
+  let platformName;
   if (!triple) {
     switch (hostPlatform) {
-      case 'win32':
-        platformName = `${lib}-win32-x64-msvc.lib`
-        break
-      case 'darwin':
-        platformName = `lib${lib}-darwin-x64.a`
-        break
-      case 'linux':
-        platformName = `lib${lib}-linux-x64-gnu.a`
-        break
+      case "win32":
+        platformName = `${lib}-win32-x64-msvc.lib`;
+        break;
+      case "darwin":
+        platformName = `lib${lib}-darwin-x64.a`;
+        break;
+      case "linux":
+        platformName = `lib${lib}-linux-x64-gnu.a`;
+        break;
       default:
-        throw new TypeError(`[${hostPlatform}] is not a valid platform`)
+        throw new TypeError(`[${hostPlatform}] is not a valid platform`);
     }
   } else {
     switch (triple) {
-      case 'aarch64-unknown-linux-gnu':
-        platformName = `lib${lib}-linux-aarch64-gnu.a`
-        break
-      case 'aarch64-unknown-linux-musl':
-        platformName = `lib${lib}-linux-aarch64-musl.a`
-        break
-      case 'armv7-unknown-linux-gnueabihf':
-        platformName = `lib${lib}-linux-armv7-gnueabihf.a`
-        break
-      case 'x86_64-unknown-linux-musl':
-        platformName = `lib${lib}-linux-x64-musl.a`
-        break
-      case 'aarch64-apple-darwin':
-        platformName = `lib${lib}-darwin-aarch64.a`
-        break
-      case 'aarch64-linux-android':
-        platformName = `lib${lib}-android-aarch64.a`
-        break
-      case 'riscv64gc-unknown-linux-gnu':
-        platformName = `lib${lib}-linux-riscv64-gnu.a`
-        break
-      case 'aarch64-pc-windows-msvc':
-        platformName = `${lib}-win32-arm64-msvc.lib`
-        break
+      case "aarch64-unknown-linux-gnu":
+        platformName = `lib${lib}-linux-aarch64-gnu.a`;
+        break;
+      case "aarch64-unknown-linux-musl":
+        platformName = `lib${lib}-linux-aarch64-musl.a`;
+        break;
+      case "armv7-unknown-linux-gnueabihf":
+        platformName = `lib${lib}-linux-armv7-gnueabihf.a`;
+        break;
+      case "x86_64-unknown-linux-musl":
+        platformName = `lib${lib}-linux-x64-musl.a`;
+        break;
+      case "aarch64-apple-darwin":
+        platformName = `lib${lib}-darwin-aarch64.a`;
+        break;
+      case "aarch64-linux-android":
+        platformName = `lib${lib}-android-aarch64.a`;
+        break;
+      case "riscv64gc-unknown-linux-gnu":
+        platformName = `lib${lib}-linux-riscv64-gnu.a`;
+        break;
+      case "aarch64-pc-windows-msvc":
+        platformName = `${lib}-win32-arm64-msvc.lib`;
+        break;
       default:
-        throw new TypeError(`[${triple}] is not a valid target`)
+        throw new TypeError(`[${triple}] is not a valid target`);
     }
   }
-  const binary = join(dirname, '..', 'skia', 'out', 'Static', hostPlatform === 'win32' ? `${lib}.lib` : `lib${lib}.a`)
+  const binary = join(
+    dirname,
+    "..",
+    "skia",
+    "out",
+    "Static",
+    hostPlatform === "win32" ? `${lib}.lib` : `lib${lib}.a`,
+  );
 
-  const copy = join(dirname, '..', platformName)
-  const downloadUrl = `https://github.com/${OWNER}/${REPO}/releases/download/${tag}/${platformName}`
-  return { binary, copy, downloadUrl, filename: platformName }
+  const copy = join(dirname, "..", platformName);
+  const downloadUrl = `https://github.com/${OWNER}/${REPO}/releases/download/${tag}/${platformName}`;
+  return { binary, copy, downloadUrl, filename: platformName };
 }


### PR DESCRIPTION
Fork rebrand pour pouvoir patcher localement et publier sur GitHub Packages.

## Changements

- Main package : `@napi-rs/canvas` → `@aphrody-code/canvas@0.1.99-fork.1`
- 11 sub-packages `npm/<target>/` renommés
- `js-binding.js` : 27 `require('@napi-rs/canvas-...')` → `@aphrody-code/canvas-...`
- `publishConfig.registry` : `registry.npmjs.org` → `npm.pkg.github.com`
- Workflow CI `Publish` : ajout setup `.npmrc` avec `GITHUB_TOKEN`, regex tag élargie aux pre-releases
- `.npmrc` ajouté au `.gitignore` (contient un PAT)

## Test publish

`bun publish` du main package (sans binaires) **a déjà réussi** vers GH Packages :
```
+ @aphrody-code/canvas@0.1.99-fork.1
```
Disponible sur `https://npm.pkg.github.com/@aphrody-code/canvas`.

Reste à déclencher la CI sur ce PR (ou push d'un tag de release) pour que les **sub-packages binaires** (Skia .node par target) soient publiés.