### PR TITLE
chore: update rust

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.94.1"
+channel = "1.95.0"
 profile = "default"

--- a/src/image.rs
+++ b/src/image.rs
@@ -334,13 +334,9 @@ impl Image {
   #[napi(setter)]
   pub fn set_src(&mut self, env: Env, this: This, raw_data: Unknown) -> Result<()> {
     let data = match raw_data.get_type()? {
-      ValueType::Object => {
-        if raw_data.is_buffer()? || raw_data.is_typedarray()? {
-          let data: Uint8Array = unsafe { raw_data.cast() }?;
-          self.src.insert(Either::A(data))
-        } else {
-          return Ok(());
-        }
+      ValueType::Object if (raw_data.is_buffer()? || raw_data.is_typedarray()?) => {
+        let data: Uint8Array = unsafe { raw_data.cast() }?;
+        self.src.insert(Either::A(data))
       }
       ValueType::String => {
         let string = unsafe { raw_data.cast()? };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk change that only updates the pinned Rust toolchain version; main impact is potential compile/lint differences in CI and local builds.
> 
> **Overview**
> Updates `rust-toolchain.toml` to pin the project to Rust **1.95.0** (from **1.94.1**), affecting the compiler version used in CI and developer environments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2425c137519559357d8d72273cd4b1f6ff49249. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->