### PR TITLE
fix: link aarch64-pc-windows-msvc against static CRT

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,9 @@
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]
 
+[target.aarch64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]
+
 [target.aarch64-apple-darwin]
 rustflags = ["-C", "target-cpu=apple-a14"]
 


### PR DESCRIPTION
## Problem

The `stable - aarch64-pc-windows-msvc - node@24` CI job fails at the **Build** step:

```
error LNK2038: mismatch detected for 'RuntimeLibrary':
  value 'MD_DynamicRelease' (mimalloc) doesn't match
  value 'MT_StaticRelease' (skiac.lib)
fatal error LNK1319: 1 mismatches detected
```

Skia and Rust/mimalloc were linked against two different C runtimes, which `link.exe` refuses to mix.

## Root cause

Skia's C wrapper is always built with the **static** CRT (`/MT`, via `.static_crt(true)` in `build.rs`), and the prebuilt Skia libs are static too. `.cargo/config.toml` forced `target-feature=+crt-static` for `x86_64-pc-windows-msvc` but **never for `aarch64-pc-windows-msvc`**, so on aarch64 Rust + mimalloc defaulted to the **dynamic** CRT (`/MD`) → mismatch.

| target | skia | Rust + mimalloc | link |
|---|---|---|---|
| `x86_64-pc-windows-msvc` | `/MT` static | `/MT` (`+crt-static`) | ✅ |
| `aarch64-pc-windows-msvc` | `/MT` static | `/MD` (no flag) | ❌ `LNK1319` |

## Why it surfaced now

The latent bug has existed since the target was added in #1176 (2025-12-17). No source or `Cargo.lock` change is involved — the only delta between the last green run (2026-05-09) and the first red run (2026-05-18) was the `windows-2025-vs2026` runner image bumping its MSVC toolset (image `20260428.85` → `20260510.103`, ~2026-05-10). The newer toolset enforces the CRT mismatch the older one tolerated.

## Fix

Add the matching `[target.aarch64-pc-windows-msvc]` `+crt-static` entry so Rust + mimalloc use the static CRT, consistent with x86_64.

## Verification

Cannot be built locally (macOS host). Verified by the `aarch64-pc-windows-msvc` build job on this PR's CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Cargo target rustflags change for Windows aarch64 only; no runtime logic or auth/data paths affected.
> 
> **Overview**
> Fixes **aarch64 Windows MSVC** link failures (`LNK2038` / `LNK1319`) where Skia and the Rust/mimalloc side were built with mismatched C runtimes.
> 
> Adds a `[target.aarch64-pc-windows-msvc]` entry in `.cargo/config.toml` with `target-feature=+crt-static`, matching the existing **x86_64-pc-windows-msvc** setup and Skia’s static CRT (`/MT`) from `build.rs`. Rust and mimalloc on aarch64 now use the static CRT instead of defaulting to `/MD`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e69c2d79c34cd619f8702ec6743946a3623c20b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->