### PR TITLE
fix: missing icudtl.dat in win32-arm64 package

### DIFF
--- a/scripts/release-skia-binary.mjs
+++ b/scripts/release-skia-binary.mjs
@@ -127,6 +127,7 @@ async function download() {
   if (PLATFORM_NAME === 'win32') {
     await downloadIcu()
     await fs.copyFile(join(dirname, '..', ICU_DAT), join(dirname, '..', 'npm', 'win32-x64-msvc', ICU_DAT))
+    await fs.copyFile(join(dirname, '..', ICU_DAT), join(dirname, '..', 'npm', 'win32-arm64-msvc', ICU_DAT))
   }
 }
 
@@ -136,6 +137,7 @@ function downloadIcu() {
     stdio: 'inherit',
   })
   copyFileSync(join(dirname, '..', ICU_DAT), join(dirname, '..', 'npm', 'win32-x64-msvc', ICU_DAT))
+  copyFileSync(join(dirname, '..', ICU_DAT), join(dirname, '..', 'npm', 'win32-arm64-msvc', ICU_DAT))
   return Promise.resolve(null)
 }
 


### PR DESCRIPTION
`@napi-rs/canvas-win32-arm64-msvc` is missing the `icudtl.dat` file, causing usage of the canvas to segfault.

