### PR TITLE
feat: chrome/m149

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -1,7 +1,7 @@
 # `skr canvas`
 
 ![CI](https://github.com/Brooooooklyn/canvas/workflows/CI/badge.svg)
-![Skia Version](https://img.shields.io/badge/Skia-chrome%2Fm148-hotpink)
+![Skia Version](https://img.shields.io/badge/Skia-chrome%2Fm149-hotpink)
 [![install size](https://packagephobia.com/badge?p=@napi-rs/canvas)](https://packagephobia.com/result?p=@napi-rs/canvas)
 [![Downloads](https://img.shields.io/npm/dm/@napi-rs/canvas.svg?sanitize=true)](https://npmcharts.com/compare/@napi-rs/canvas?minimal=true)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `skr canvas`
 
 [![CI](https://github.com/Brooooooklyn/canvas/actions/workflows/CI.yaml/badge.svg)](https://github.com/Brooooooklyn/canvas/actions/workflows/CI.yaml)
-![Skia Version](https://img.shields.io/badge/Skia-chrome%2Fm148-hotpink)
+![Skia Version](https://img.shields.io/badge/Skia-chrome%2Fm149-hotpink)
 [![install size](https://packagephobia.com/badge?p=@napi-rs/canvas)](https://packagephobia.com/result?p=@napi-rs/canvas)
 [![Downloads](https://img.shields.io/npm/dm/@napi-rs/canvas.svg?sanitize=true)](https://npmcharts.com/compare/@napi-rs/canvas?minimal=true)
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only badge text change with no impact on library behavior or binaries in this diff.
> 
> **Overview**
> Updates the **Skia Version** shield in `README.md` and `README-zh.md` from `chrome/m148` to **`chrome/m149`**, so the docs match the Chrome milestone tied to this release.
> 
> No runtime, build, or API code appears in this diff—only the badge URL text changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a5f0d1fba9b79dfa62e4ebb1f1df359de6745c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->