### PR TITLE
feat: chrome/m151

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -1,7 +1,7 @@
 # `skr canvas`
 
 ![CI](https://github.com/Brooooooklyn/canvas/workflows/CI/badge.svg)
-![Skia Version](https://img.shields.io/badge/Skia-chrome%2Fm149-hotpink)
+![Skia Version](https://img.shields.io/badge/Skia-chrome%2Fm151-hotpink)
 [![install size](https://packagephobia.com/badge?p=@napi-rs/canvas)](https://packagephobia.com/result?p=@napi-rs/canvas)
 [![Downloads](https://img.shields.io/npm/dm/@napi-rs/canvas.svg?sanitize=true)](https://npmcharts.com/compare/@napi-rs/canvas?minimal=true)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `skr canvas`
 
 [![CI](https://github.com/Brooooooklyn/canvas/actions/workflows/CI.yaml/badge.svg)](https://github.com/Brooooooklyn/canvas/actions/workflows/CI.yaml)
-![Skia Version](https://img.shields.io/badge/Skia-chrome%2Fm149-hotpink)
+![Skia Version](https://img.shields.io/badge/Skia-chrome%2Fm151-hotpink)
 [![install size](https://packagephobia.com/badge?p=@napi-rs/canvas)](https://packagephobia.com/result?p=@napi-rs/canvas)
 [![Downloads](https://img.shields.io/npm/dm/@napi-rs/canvas.svg?sanitize=true)](https://npmcharts.com/compare/@napi-rs/canvas?minimal=true)
 

--- a/scripts/build-skia.js
+++ b/scripts/build-skia.js
@@ -115,6 +115,11 @@ const GN_ARGS = [
   `skia_use_system_harfbuzz=false`,
   `skia_use_lua=false`,
   `skia_use_piex=false`,
+  // Skia defaults this to `is_clang`, which pulls PartitionAlloc into libskia. Its Linux code
+  // needs glibc (sys/cdefs.h, sys/ifunc.h, AT_HWCAP2), breaking musl and the glibc 2.17 aarch64
+  // sysroot. The PartitionAlloc archives are never uploaded or linked either, so libskia would
+  // ship unresolved raw_ptr/BackupRefPtr symbols.
+  `skia_use_partition_alloc=false`,
   `skia_enable_fontmgr_custom_directory=true`,
   `skia_enable_fontmgr_custom_embedded=false`,
   `skia_enable_fontmgr_custom_empty=true`,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes native Skia compilation for all targets; disabling PartitionAlloc is a deliberate portability fix but alters how upstream Skia is built and linked.
> 
> **Overview**
> Bumps the documented Skia baseline from **chrome/m149** to **chrome/m151** in `README.md` and `README-zh.md`.
> 
> In `scripts/build-skia.js`, adds **`skia_use_partition_alloc=false`** to the GN args so Skia no longer pulls PartitionAlloc into `libskia`. Newer Skia defaults this on for Clang builds; that Linux code depends on glibc-only headers and breaks **musl** and **glibc 2.17 aarch64** sysroot builds. The project also does not ship or link PartitionAlloc archives, which would leave unresolved `raw_ptr` / `BackupRefPtr` symbols.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fef7fcb11ffd00adffbd0b6dbe506e3f11a287a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->