### PR TITLE
fix: prefer raster signatures over SVG markers

### DIFF
--- a/__test__/loadimage.spec.ts
+++ b/__test__/loadimage.spec.ts
@@ -57,6 +57,17 @@ test('should load data uri', async (t) => {
   t.is(img instanceof Image, true)
 })
 
+test('should prefer a PNG signature over an SVG marker in the buffer (issue #1308)', async (t) => {
+  const canvas = createCanvas(64, 64)
+  const png = canvas.toBuffer('image/png')
+  const pngWithSvgMarker = Buffer.concat([png, Buffer.from('<svg xmlns')])
+
+  const img = await loadImage(pngWithSvgMarker)
+
+  t.is(img.width, 64)
+  t.is(img.height, 64)
+})
+
 test('should draw img', async (t) => {
   const img = await loadImage(
     'https://raw.githubusercontent.com/Brooooooklyn/canvas/462fce53afeaee6d6b4ae5d1b407c17e2359ff7e/example/anime-girl.png',

--- a/src/image.rs
+++ b/src/image.rs
@@ -392,8 +392,13 @@ impl Image {
       let buffer_data = buffer.as_ref();
       let length = buffer_data.len();
 
-      // Check if it's SVG (imagesize doesn't support SVG)
-      let is_svg = is_svg_image(buffer_data, length);
+      // Known raster signatures take precedence over the permissive SVG scan.
+      // Raster payloads may legitimately contain the bytes `<svg` in metadata or
+      // compressed data, and the async decoder uses the same raster-first order.
+      let is_raster = libavif::is_avif(buffer_data)
+        || infer::get(buffer_data)
+          .is_some_and(|kind| kind.matcher_type() == infer::MatcherType::Image);
+      let is_svg = !is_raster && is_svg_image(buffer_data, length);
       // Try to extract dimensions from image header using imagesize (fast, no full decode)
       let (img_width, img_height, is_valid_image) = if is_svg {
         // For SVG, we'll get dimensions after decode; for invalid images, we'll error


### PR DESCRIPTION
## Summary

- give recognized raster signatures precedence over the permissive SVG buffer scan
- preserve the existing SVG detection behavior for buffers without a known raster signature
- add regression coverage for PNG data containing a later `<svg` marker

## Root cause

The synchronous `Image.src = Buffer` preflight checked `is_svg_image` before consulting any raster signature. Because that detector scans beyond the image header, a valid PNG containing the bytes `<svg` in metadata, compressed data, or trailing data was synchronously handed to the SVG parser and rejected as `Invalid SVG image`. The asynchronous decoder already used raster-first precedence.

This change aligns the synchronous preflight with the decoder so PNG, JPEG, GIF, WebP, AVIF, and other recognized image formats cannot be misclassified by bytes later in their payload.

Closes #1308

## Validation

- `yarn build:debug`
- `cargo fmt -- --check`
- `cargo clippy`
- `yarn lint`
- `yarn ava __test__/loadimage.spec.ts __test__/image.spec.ts` — 83 passed, 1 known failure
- `yarn test:ci` — 605 passed, 1 known failure, 13 skipped

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to buffer format detection order in `set_src`, aligned with existing async decode logic; regression test covers the reported case.
> 
> **Overview**
> Fixes **#1308**: valid raster buffers were sometimes classified as SVG during the synchronous `Image.src = Buffer` preflight because `is_svg_image` scans the whole buffer. That path could reject a real PNG (or other raster) with a synchronous **Invalid SVG image** error even though the async decoder already handled the same bytes correctly.
> 
> The sync preflight now matches the decoder: it checks **AVIF** and **`infer` image signatures** first, and only runs the SVG marker scan when no known raster type is detected. Buffers that are genuinely SVG-only behavior are unchanged.
> 
> A regression test loads a PNG with trailing `<svg xmlns` bytes via `loadImage` and asserts **64×64** dimensions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ab6fd2615c53711ec9799c3e97ebab95a901cb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->