### PR TITLE
fix: reject malformed raster images

### DIFF
--- a/__test__/loadimage.spec.ts
+++ b/__test__/loadimage.spec.ts
@@ -5,6 +5,7 @@ import { readFile } from 'node:fs/promises'
 import { URL, pathToFileURL, fileURLToPath } from 'node:url'
 
 import test from 'ava'
+import { crc32 } from '@node-rs/crc32'
 
 import { createCanvas, Image, loadImage } from '../index'
 
@@ -136,17 +137,6 @@ test('loadImage settles on invalid base64 data URL (issue #1255)', async (t) => 
 // Regression tests for https://github.com/Brooooooklyn/canvas/issues/1309
 // Run malformed inputs in child processes so a native crash is reported as a
 // test failure instead of terminating the entire test runner.
-
-function crc32(buffer: Buffer): number {
-  let crc = -1
-  for (const byte of buffer) {
-    crc ^= byte
-    for (let bit = 0; bit < 8; bit++) {
-      crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0)
-    }
-  }
-  return (crc ^ -1) >>> 0
-}
 
 function patchIhdr(png: Buffer, width: number, height: number, colorType?: number): Buffer {
   const result = Buffer.from(png)

--- a/__test__/loadimage.spec.ts
+++ b/__test__/loadimage.spec.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from 'node:child_process'
+import { spawn } from 'node:child_process'
 import { join, dirname } from 'node:path'
 import fs from 'node:fs'
 import { readFile } from 'node:fs/promises'
@@ -157,7 +157,48 @@ function patchIhdr(png: Buffer, width: number, height: number, colorType?: numbe
   return result
 }
 
-test('loadImage rejects malformed raster images without terminating the process (issue #1309)', (t) => {
+function runInChildProcess(
+  script: string,
+  args: string[],
+): Promise<{
+  status: number | null
+  signal: NodeJS.Signals | null
+  stdout: string
+  stderr: string
+}> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ['-e', script, ...args], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+
+    child.stdout.setEncoding('utf8')
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk
+    })
+    child.stderr.setEncoding('utf8')
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk
+    })
+
+    const timer = setTimeout(() => {
+      child.kill()
+      reject(new Error('Child process timed out after 10 seconds'))
+    }, 10_000)
+
+    child.on('error', (error) => {
+      clearTimeout(timer)
+      reject(error)
+    })
+    child.on('close', (status, signal) => {
+      clearTimeout(timer)
+      resolve({ status, signal, stdout, stderr })
+    })
+  })
+}
+
+test('loadImage rejects malformed raster images without terminating the process (issue #1309)', async (t) => {
   const canvas = createCanvas(64, 64)
   const ctx = canvas.getContext('2d')
   ctx.fillStyle = '#345678'
@@ -193,12 +234,8 @@ test('loadImage rejects malformed raster images without terminating the process 
   `
 
   for (const [name, image] of malformedImages) {
-    const child = spawnSync(process.execPath, ['-e', script, entrypoint, image.toString('base64')], {
-      encoding: 'utf8',
-      timeout: 10_000,
-    })
+    const child = await runInChildProcess(script, [entrypoint, image.toString('base64')])
 
-    t.falsy(child.error, `${name}: ${child.error?.message}`)
     t.is(child.signal, null, `${name}: child terminated with ${child.signal}\n${child.stderr}`)
     t.is(child.status, 0, `${name}: child exited with ${child.status}\n${child.stderr}`)
     t.regex(child.stdout, /^rejected: Unsupported image type\n$/, name)

--- a/__test__/loadimage.spec.ts
+++ b/__test__/loadimage.spec.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from 'node:child_process'
 import { join, dirname } from 'node:path'
 import fs from 'node:fs'
 import { readFile } from 'node:fs/promises'
@@ -130,4 +131,86 @@ test('loadImage settles on tiny invalid Buffer (issue #1255)', async (t) => {
 test('loadImage settles on invalid base64 data URL (issue #1255)', async (t) => {
   const result = await settles(loadImage('data:image/png;base64,=').catch((e) => e))
   t.not(result, TIMEOUT_SENTINEL, 'loadImage("data:image/png;base64,=") hung')
+})
+
+// Regression tests for https://github.com/Brooooooklyn/canvas/issues/1309
+// Run malformed inputs in child processes so a native crash is reported as a
+// test failure instead of terminating the entire test runner.
+
+function crc32(buffer: Buffer): number {
+  let crc = -1
+  for (const byte of buffer) {
+    crc ^= byte
+    for (let bit = 0; bit < 8; bit++) {
+      crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0)
+    }
+  }
+  return (crc ^ -1) >>> 0
+}
+
+function patchIhdr(png: Buffer, width: number, height: number, colorType?: number): Buffer {
+  const result = Buffer.from(png)
+  result.writeUInt32BE(width, 16)
+  result.writeUInt32BE(height, 20)
+  if (colorType !== undefined) result[25] = colorType
+  result.writeUInt32BE(crc32(result.subarray(12, 29)), 29)
+  return result
+}
+
+test('loadImage rejects malformed raster images without terminating the process (issue #1309)', (t) => {
+  const canvas = createCanvas(64, 64)
+  const ctx = canvas.getContext('2d')
+  ctx.fillStyle = '#345678'
+  ctx.fillRect(0, 0, 64, 64)
+  const png = canvas.toBuffer('image/png')
+
+  const jpegSignature = Buffer.from(png)
+  jpegSignature.set([0xff, 0xd8, 0xff, 0xe0], 0)
+
+  const malformedImages = [
+    ['PNG truncated mid-IDAT', png.subarray(0, 40)],
+    ['PNG truncated after IHDR', png.subarray(0, 33)],
+    [
+      'PNG signature with random data and IEND',
+      Buffer.concat([png.subarray(0, 8), Buffer.from('malformed raster payload'), png.subarray(-12)]),
+    ],
+    ['PNG with invalid color type', patchIhdr(png, 64, 64, 9)],
+    ['PNG with zero dimensions', patchIhdr(png, 0, 0)],
+    ['PNG payload with a JPEG signature', jpegSignature],
+    ['PNG with excessive dimensions', patchIhdr(png, 100_000, 100_000)],
+  ] as const
+
+  const entrypoint = join(__dirname, '..', 'index.js')
+  const script = `
+    const { loadImage } = require(process.argv[1])
+    loadImage(Buffer.from(process.argv[2], 'base64')).then(
+      () => {
+        console.error('unexpectedly resolved')
+        process.exitCode = 2
+      },
+      (error) => console.log('rejected:', error.message),
+    )
+  `
+
+  for (const [name, image] of malformedImages) {
+    const child = spawnSync(process.execPath, ['-e', script, entrypoint, image.toString('base64')], {
+      encoding: 'utf8',
+      timeout: 10_000,
+    })
+
+    t.falsy(child.error, `${name}: ${child.error?.message}`)
+    t.is(child.signal, null, `${name}: child terminated with ${child.signal}\n${child.stderr}`)
+    t.is(child.status, 0, `${name}: child exited with ${child.status}\n${child.stderr}`)
+    t.regex(child.stdout, /^rejected: Unsupported image type\n$/, name)
+  }
+})
+
+test('loadImage preserves Skia partial decoding for sufficiently complete PNG data (issue #1309)', async (t) => {
+  const canvas = createCanvas(64, 64)
+  const png = canvas.toBuffer('image/png')
+
+  const image = await loadImage(png.subarray(0, 119))
+
+  t.is(image.width, 64)
+  t.is(image.height, 64)
 })

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@jimp/png": "^0.22.12",
     "@napi-rs/cli": "^3.5.0",
     "@napi-rs/webcodecs": "^1.1.1",
+    "@node-rs/crc32": "^1.10.6",
     "@octokit/rest": "^22.0.1",
     "@oxc-node/cli": "^0.1.0",
     "@oxc-node/core": "^0.1.0",

--- a/skia-c/skia_c.cpp
+++ b/skia-c/skia_c.cpp
@@ -1,6 +1,7 @@
 #include <assert.h>
 #include <math.h>
 #include <algorithm>
+#include <memory>
 #include <optional>
 #include <vector>
 
@@ -1976,11 +1977,14 @@ void skiac_sk_data_destroy(skiac_data* c_data) {
 
 // Bitmap
 
-void skiac_bitmap_make_from_buffer(const uint8_t* ptr,
+bool skiac_bitmap_make_from_buffer(const uint8_t* ptr,
                                    size_t size,
                                    skiac_bitmap_info* bitmap_info) {
   auto data = SkData::MakeWithoutCopy(reinterpret_cast<const void*>(ptr), size);
   auto codec = SkCodec::MakeFromData(data);
+  if (!codec) {
+    return false;
+  }
   auto info = codec->getInfo();
   // PNG/WebP/GIF codecs report unpremultiplied alpha (required by those
   // formats on disk). Ask the codec to output premultiplied pixels so that
@@ -1991,9 +1995,15 @@ void skiac_bitmap_make_from_buffer(const uint8_t* ptr,
     info = info.makeAlphaType(kPremul_SkAlphaType);
   }
   auto row_bytes = info.minRowBytes();
-  auto bitmap = new SkBitmap();
-  bitmap->allocPixels(info);
-  codec->getPixels(info, bitmap->getPixels(), row_bytes);
+  auto bitmap = std::make_unique<SkBitmap>();
+  if (!bitmap->tryAllocPixels(info)) {
+    return false;
+  }
+  auto result = codec->getPixels(info, bitmap->getPixels(), row_bytes);
+  if (result != SkCodec::kSuccess && result != SkCodec::kIncompleteInput &&
+      result != SkCodec::kErrorInInput) {
+    return false;
+  }
   auto dimension = codec->dimensions();
   auto origin = codec->getOrigin();
   auto width = dimension.width();
@@ -2008,25 +2018,30 @@ void skiac_bitmap_make_from_buffer(const uint8_t* ptr,
       width = height;
       height = dimension.width();
     }
-    auto oriented_bitmap = new SkBitmap();
+    auto oriented_bitmap = std::make_unique<SkBitmap>();
     auto oriented_bitmap_info =
         SkImageInfo::Make(width, height, info.colorType(), info.alphaType());
-    oriented_bitmap->allocPixels(oriented_bitmap_info);
-    auto canvas = new SkCanvas(*oriented_bitmap);
+    if (!oriented_bitmap->tryAllocPixels(oriented_bitmap_info)) {
+      return false;
+    }
+    SkCanvas canvas(*oriented_bitmap);
     auto matrix = SkEncodedOriginToMatrix(origin, width, height);
-    canvas->setMatrix(matrix);
+    canvas.setMatrix(matrix);
     auto image = SkImages::RasterFromBitmap(*bitmap);
-    canvas->drawImage(image, 0, 0);
-    delete canvas;
+    if (!image) {
+      return false;
+    }
+    canvas.drawImage(image, 0, 0);
     oriented_bitmap->setImmutable();
-    bitmap_info->bitmap = reinterpret_cast<skiac_bitmap*>(oriented_bitmap);
-    delete bitmap;
+    bitmap_info->bitmap =
+        reinterpret_cast<skiac_bitmap*>(oriented_bitmap.release());
   } else {
     bitmap->setImmutable();
-    bitmap_info->bitmap = reinterpret_cast<skiac_bitmap*>(bitmap);
+    bitmap_info->bitmap = reinterpret_cast<skiac_bitmap*>(bitmap.release());
   }
   bitmap_info->width = width;
   bitmap_info->height = height;
+  return true;
 }
 
 bool skiac_bitmap_make_from_svg(const uint8_t* data,

--- a/skia-c/skia_c.hpp
+++ b/skia-c/skia_c.hpp
@@ -1183,7 +1183,7 @@ void skiac_canvas_draw_sk_image(skiac_canvas* c_canvas,
 void skiac_sk_data_destroy(skiac_data* c_data);
 
 // Bitmap
-void skiac_bitmap_make_from_buffer(const uint8_t* ptr,
+bool skiac_bitmap_make_from_buffer(const uint8_t* ptr,
                                    size_t size,
                                    skiac_bitmap_info* bitmap_info);
 bool skiac_bitmap_make_from_svg(const uint8_t* data,

--- a/src/image.rs
+++ b/src/image.rs
@@ -1024,11 +1024,17 @@ impl<'env> ScopedTask<'env> for BitmapDecoder {
           .map_err(|e| Error::new(Status::InvalidArg, format!("Decode data url failed {e}")))?;
         if let Some(kind) = infer::get(&image_binary) {
           if kind.matcher_type() == infer::MatcherType::Image {
-            DecodeStatus::Ok(BitmapInfo {
-              data: Bitmap::from_buffer(image_binary.as_ptr().cast_mut(), image_binary.len()),
-              is_svg: false,
-              decoded_image: None,
-            })
+            if let Some(bitmap) =
+              Bitmap::from_buffer(image_binary.as_ptr().cast_mut(), image_binary.len())
+            {
+              DecodeStatus::Ok(BitmapInfo {
+                data: bitmap,
+                is_svg: false,
+                decoded_image: None,
+              })
+            } else {
+              DecodeStatus::InvalidImage
+            }
           } else {
             DecodeStatus::InvalidImage
           }
@@ -1063,11 +1069,15 @@ impl<'env> ScopedTask<'env> for BitmapDecoder {
       false
     } {
       // Other image formats detected by infer (PNG, JPEG, GIF, WebP, etc.)
-      DecodeStatus::Ok(BitmapInfo {
-        data: Bitmap::from_buffer(data_ref.as_ptr().cast_mut(), length),
-        is_svg: false,
-        decoded_image: None,
-      })
+      if let Some(bitmap) = Bitmap::from_buffer(data_ref.as_ptr().cast_mut(), length) {
+        DecodeStatus::Ok(BitmapInfo {
+          data: bitmap,
+          is_svg: false,
+          decoded_image: None,
+        })
+      } else {
+        DecodeStatus::InvalidImage
+      }
     } else if is_svg_image(&data_ref, length) {
       let font = get_font().map_err(SkError::from)?;
       if (self.width - -1.0).abs() > f64::EPSILON && (self.height - -1.0).abs() > f64::EPSILON {

--- a/src/sk.rs
+++ b/src/sk.rs
@@ -1008,7 +1008,11 @@ pub mod ffi {
 
     pub fn skiac_sk_data_destroy(c_data: *mut skiac_data);
 
-    pub fn skiac_bitmap_make_from_buffer(ptr: *mut u8, size: usize, info: *mut skiac_bitmap_info);
+    pub fn skiac_bitmap_make_from_buffer(
+      ptr: *mut u8,
+      size: usize,
+      info: *mut skiac_bitmap_info,
+    ) -> bool;
 
     pub fn skiac_bitmap_make_from_svg(
       data: *const u8,
@@ -4129,7 +4133,7 @@ unsafe impl Send for Bitmap {}
 unsafe impl Sync for Bitmap {}
 
 impl Bitmap {
-  pub fn from_buffer(ptr: *mut u8, size: usize) -> Self {
+  pub fn from_buffer(ptr: *mut u8, size: usize) -> Option<Self> {
     let mut bitmap_info = ffi::skiac_bitmap_info {
       bitmap: ptr::null_mut(),
       width: 0,
@@ -4137,8 +4141,11 @@ impl Bitmap {
       is_canvas: false,
     };
     unsafe {
-      ffi::skiac_bitmap_make_from_buffer(ptr, size, &mut bitmap_info);
-      Bitmap(bitmap_info)
+      if ffi::skiac_bitmap_make_from_buffer(ptr, size, &mut bitmap_info) {
+        Some(Bitmap(bitmap_info))
+      } else {
+        None
+      }
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -118,6 +118,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emnapi/core@npm:^1.4.3":
+  version: 1.11.3
+  resolution: "@emnapi/core@npm:1.11.3"
+  dependencies:
+    "@emnapi/wasi-threads": "npm:1.2.3"
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/4ca08d349a82d5d2887ccc9e12df630877b0412ddcd59b9faee61e3c3947ccead27a18257a18bfe17abdf2b0709857808ad75d423ac49edd50c32fb140a7ed6e
+  languageName: node
+  linkType: hard
+
 "@emnapi/runtime@npm:1.11.2":
   version: 1.11.2
   resolution: "@emnapi/runtime@npm:1.11.2"
@@ -145,6 +155,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emnapi/runtime@npm:^1.4.3":
+  version: 1.11.3
+  resolution: "@emnapi/runtime@npm:1.11.3"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/a00f1020fefb9d4145c367f93a9fddb383a00da8ffd7871e20b19659890379b83aeecb9f84d7d0eda5456343f4a09eb05b0acb5153b0d3d889539dedb1ed87c3
+  languageName: node
+  linkType: hard
+
 "@emnapi/wasi-threads@npm:1.2.0":
   version: 1.2.0
   resolution: "@emnapi/wasi-threads@npm:1.2.0"
@@ -169,6 +188,15 @@ __metadata:
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 10c0/f0dc8269d6b20ae5a7c7b36e7a6a333452009d461038ef4febb29da2f3f78c1e2b1576d7e8970a5c5789ed3caedc1f80f5b0c2a5373bdaf8d03b20432bb55747
+  languageName: node
+  linkType: hard
+
+"@emnapi/wasi-threads@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@emnapi/wasi-threads@npm:1.2.3"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/5aed84bc5dbe867973b20406ca1ed95661a4892ecaef80378fdf2d37424b3f7b9c428df8a3e1d82b783a3345a530032bf049e699e1f113ea52203c3e9b4e6ce5
   languageName: node
   linkType: hard
 
@@ -611,6 +639,7 @@ __metadata:
     "@jimp/png": "npm:^0.22.12"
     "@napi-rs/cli": "npm:^3.5.0"
     "@napi-rs/webcodecs": "npm:^1.1.1"
+    "@node-rs/crc32": "npm:^1.10.6"
     "@octokit/rest": "npm:^22.0.1"
     "@oxc-node/cli": "npm:^0.1.0"
     "@oxc-node/core": "npm:^0.1.0"
@@ -1077,6 +1106,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@napi-rs/wasm-runtime@npm:^0.2.5":
+  version: 0.2.12
+  resolution: "@napi-rs/wasm-runtime@npm:0.2.12"
+  dependencies:
+    "@emnapi/core": "npm:^1.4.3"
+    "@emnapi/runtime": "npm:^1.4.3"
+    "@tybys/wasm-util": "npm:^0.10.0"
+  checksum: 10c0/6d07922c0613aab30c6a497f4df297ca7c54e5b480e00035e0209b872d5c6aab7162fc49477267556109c2c7ed1eb9c65a174e27e9b87568106a87b0a6e3ca7d
+  languageName: node
+  linkType: hard
+
 "@napi-rs/wasm-runtime@npm:^1.1.2, @napi-rs/wasm-runtime@npm:^1.1.6":
   version: 1.2.1
   resolution: "@napi-rs/wasm-runtime@npm:1.2.1"
@@ -1333,6 +1373,157 @@ __metadata:
     "@napi-rs/canvas":
       optional: true
   checksum: 10c0/00540514b7de4df522bf5d0de811be67570d0fd8bddd48ef2138797e0f2c3f911a915ee46fe59ca13d1c7e8a3be5205a7894d5044ce1f749a5134dc0863c4305
+  languageName: node
+  linkType: hard
+
+"@node-rs/crc32-android-arm-eabi@npm:1.10.6":
+  version: 1.10.6
+  resolution: "@node-rs/crc32-android-arm-eabi@npm:1.10.6"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@node-rs/crc32-android-arm64@npm:1.10.6":
+  version: 1.10.6
+  resolution: "@node-rs/crc32-android-arm64@npm:1.10.6"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@node-rs/crc32-darwin-arm64@npm:1.10.6":
+  version: 1.10.6
+  resolution: "@node-rs/crc32-darwin-arm64@npm:1.10.6"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@node-rs/crc32-darwin-x64@npm:1.10.6":
+  version: 1.10.6
+  resolution: "@node-rs/crc32-darwin-x64@npm:1.10.6"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@node-rs/crc32-freebsd-x64@npm:1.10.6":
+  version: 1.10.6
+  resolution: "@node-rs/crc32-freebsd-x64@npm:1.10.6"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@node-rs/crc32-linux-arm-gnueabihf@npm:1.10.6":
+  version: 1.10.6
+  resolution: "@node-rs/crc32-linux-arm-gnueabihf@npm:1.10.6"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@node-rs/crc32-linux-arm64-gnu@npm:1.10.6":
+  version: 1.10.6
+  resolution: "@node-rs/crc32-linux-arm64-gnu@npm:1.10.6"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@node-rs/crc32-linux-arm64-musl@npm:1.10.6":
+  version: 1.10.6
+  resolution: "@node-rs/crc32-linux-arm64-musl@npm:1.10.6"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@node-rs/crc32-linux-x64-gnu@npm:1.10.6":
+  version: 1.10.6
+  resolution: "@node-rs/crc32-linux-x64-gnu@npm:1.10.6"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@node-rs/crc32-linux-x64-musl@npm:1.10.6":
+  version: 1.10.6
+  resolution: "@node-rs/crc32-linux-x64-musl@npm:1.10.6"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@node-rs/crc32-wasm32-wasi@npm:1.10.6":
+  version: 1.10.6
+  resolution: "@node-rs/crc32-wasm32-wasi@npm:1.10.6"
+  dependencies:
+    "@napi-rs/wasm-runtime": "npm:^0.2.5"
+  conditions: cpu=wasm32
+  languageName: node
+  linkType: hard
+
+"@node-rs/crc32-win32-arm64-msvc@npm:1.10.6":
+  version: 1.10.6
+  resolution: "@node-rs/crc32-win32-arm64-msvc@npm:1.10.6"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@node-rs/crc32-win32-ia32-msvc@npm:1.10.6":
+  version: 1.10.6
+  resolution: "@node-rs/crc32-win32-ia32-msvc@npm:1.10.6"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@node-rs/crc32-win32-x64-msvc@npm:1.10.6":
+  version: 1.10.6
+  resolution: "@node-rs/crc32-win32-x64-msvc@npm:1.10.6"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@node-rs/crc32@npm:^1.10.6":
+  version: 1.10.6
+  resolution: "@node-rs/crc32@npm:1.10.6"
+  dependencies:
+    "@node-rs/crc32-android-arm-eabi": "npm:1.10.6"
+    "@node-rs/crc32-android-arm64": "npm:1.10.6"
+    "@node-rs/crc32-darwin-arm64": "npm:1.10.6"
+    "@node-rs/crc32-darwin-x64": "npm:1.10.6"
+    "@node-rs/crc32-freebsd-x64": "npm:1.10.6"
+    "@node-rs/crc32-linux-arm-gnueabihf": "npm:1.10.6"
+    "@node-rs/crc32-linux-arm64-gnu": "npm:1.10.6"
+    "@node-rs/crc32-linux-arm64-musl": "npm:1.10.6"
+    "@node-rs/crc32-linux-x64-gnu": "npm:1.10.6"
+    "@node-rs/crc32-linux-x64-musl": "npm:1.10.6"
+    "@node-rs/crc32-wasm32-wasi": "npm:1.10.6"
+    "@node-rs/crc32-win32-arm64-msvc": "npm:1.10.6"
+    "@node-rs/crc32-win32-ia32-msvc": "npm:1.10.6"
+    "@node-rs/crc32-win32-x64-msvc": "npm:1.10.6"
+  dependenciesMeta:
+    "@node-rs/crc32-android-arm-eabi":
+      optional: true
+    "@node-rs/crc32-android-arm64":
+      optional: true
+    "@node-rs/crc32-darwin-arm64":
+      optional: true
+    "@node-rs/crc32-darwin-x64":
+      optional: true
+    "@node-rs/crc32-freebsd-x64":
+      optional: true
+    "@node-rs/crc32-linux-arm-gnueabihf":
+      optional: true
+    "@node-rs/crc32-linux-arm64-gnu":
+      optional: true
+    "@node-rs/crc32-linux-arm64-musl":
+      optional: true
+    "@node-rs/crc32-linux-x64-gnu":
+      optional: true
+    "@node-rs/crc32-linux-x64-musl":
+      optional: true
+    "@node-rs/crc32-wasm32-wasi":
+      optional: true
+    "@node-rs/crc32-win32-arm64-msvc":
+      optional: true
+    "@node-rs/crc32-win32-ia32-msvc":
+      optional: true
+    "@node-rs/crc32-win32-x64-msvc":
+      optional: true
+  checksum: 10c0/536efd0f847f49a12c2c48610dee1de55e88f03873769a04d0d86f3d96610d71ade7d1e021b44fb3e91d54cda2e78c9e659b46cbaf88a0907a2cbf2b16030cb6
   languageName: node
   linkType: hard
 
@@ -1923,7 +2114,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tybys/wasm-util@npm:^0.10.3":
+"@tybys/wasm-util@npm:^0.10.0, @tybys/wasm-util@npm:^0.10.3":
   version: 0.10.3
   resolution: "@tybys/wasm-util@npm:0.10.3"
   dependencies:


### PR DESCRIPTION
## Summary

- make Skia raster decoding fail safely when codec creation, pixel allocation, or decoding fails
- propagate native decode failures through the existing `loadImage` promise rejection path
- preserve Skia's supported partial-image decoding behavior
- cover every malformed PNG shape reported in #1309 in isolated child processes

## Root cause

The native bitmap bridge assumed `SkCodec::MakeFromData` always returned a codec, used fatal `SkBitmap::allocPixels` calls, and ignored the result of `SkCodec::getPixels`. Malformed or oversized inputs could therefore dereference a null codec or abort during allocation instead of rejecting `loadImage`.

## Validation

- `yarn build`
- `yarn ava __test__/loadimage.spec.ts --serial` (15 passed)
- `yarn test:ci` (607 passed, 1 existing expected failure, 13 skipped)
- `cargo test` (33 passed)
- `yarn lint`
- `yarn prettier __test__/loadimage.spec.ts --check`
- `cargo fmt --check`

Closes #1309

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core native image decode used by `loadImage`; behavior change is intentional (more rejections, no crashes) but affects all raster formats going through `skiac_bitmap_make_from_buffer`.
> 
> **Overview**
> Fixes **native crashes/abort on malformed raster buffers** (#1309) by hardening the Skia decode bridge and treating decode failure as a normal `loadImage` rejection instead of proceeding with invalid state.
> 
> **Native (`skiac_bitmap_make_from_buffer`)** now returns **`bool`**: bail out when `SkCodec::MakeFromData` fails, use **`tryAllocPixels`** instead of fatal allocation, check **`getPixels`** (while still allowing Skia’s partial decode outcomes `kIncompleteInput` / `kErrorInInput`), and tighten orientation handling with safer bitmap/canvas ownership.
> 
> **Rust** maps that to **`Bitmap::from_buffer` → `Option`**, and **`src/image.rs`** only succeeds when a bitmap is produced; otherwise decode becomes **`InvalidImage`** (existing “Unsupported image type” path) for both raw buffers and data URLs.
> 
> **Tests** add issue #1309 coverage: malformed PNG variants are exercised in **isolated child processes** (so a native crash fails one test, not the runner), plus a check that **sufficiently complete truncated PNG** still partially decodes. Dev-only **`@node-rs/crc32`** supports crafting invalid IHDR chunks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c65d3f4c11cfd20ee18360dca2a4ecac374cc12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->