### PR TITLE
fix: keep skia surface alive during async encode (#1312)

### DIFF
--- a/__test__/issue-1312-encode-gc.spec.ts
+++ b/__test__/issue-1312-encode-gc.spec.ts
@@ -1,0 +1,137 @@
+import { spawn } from 'node:child_process'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import test from 'ava'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+function runInChildProcess(
+  script: string,
+  nodeArgs: string[] = [],
+  timeoutMs = 180_000,
+): Promise<{
+  status: number | null
+  signal: NodeJS.Signals | null
+  stdout: string
+  stderr: string
+}> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [...nodeArgs, '-e', script], {
+      cwd: root,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+
+    child.stdout.setEncoding('utf8')
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk
+    })
+    child.stderr.setEncoding('utf8')
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk
+    })
+
+    const timer = setTimeout(() => {
+      child.kill()
+      reject(new Error(`Child process timed out after ${timeoutMs}ms`))
+    }, timeoutMs)
+
+    child.on('error', (error) => {
+      clearTimeout(timer)
+      reject(error)
+    })
+    child.on('close', (status, signal) => {
+      clearTimeout(timer)
+      resolve({ status, signal, stdout, stderr })
+    })
+  })
+}
+
+// A canvas that is not held alive across the await must still be kept
+// native-alive by the async encode task itself (issue #1312).
+test('encode() completes when the canvas is not referenced across the await', async (t) => {
+  const { status, signal, stdout, stderr } = await runInChildProcess(`
+const { createCanvas } = require('./index.js')
+function kick() {
+  const canvas = createCanvas(1024, 1024)
+  canvas.getContext('2d').fillRect(0, 0, 1024, 1024)
+  return canvas.encode('png')
+}
+;(async () => {
+  for (let round = 1; round <= 5; round += 1) {
+    await Promise.all(Array.from({ length: 64 }, () => kick()))
+    console.log('Completed round ' + round + '.')
+  }
+})().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})
+`)
+
+  t.is(status, 0, `expected exit 0, got status=${status} signal=${signal}\n${stderr}${stdout}`)
+  t.true(stdout.includes('Completed round 5.'), `unexpected output:\n${stdout}`)
+})
+
+test('encode() survives garbage collection of the canvas while the encode is in flight', async (t) => {
+  const { status, signal, stdout, stderr } = await runInChildProcess(
+    `
+const { createCanvas } = require('./index.js')
+const pending = new Set()
+const registry = new FinalizationRegistry((held) => pending.delete(held))
+let finalizedWhilePending = 0
+let total = 0
+function kick() {
+  const canvas = createCanvas(1024, 1024)
+  canvas.getContext('2d').fillRect(0, 0, 1024, 1024)
+  const held = {}
+  pending.add(held)
+  registry.register(canvas, held)
+  const promise = canvas.encode('png')
+  promise.then(() => {
+    if (!pending.has(held)) finalizedWhilePending += 1
+    total += 1
+  })
+  return promise
+}
+;(async () => {
+  for (let round = 1; round <= 5; round += 1) {
+    const jobs = Array.from({ length: 8 }, () => kick())
+    global.gc()
+    await Promise.all(jobs)
+    console.log('Round ' + round + ': finalizedWhilePending=' + finalizedWhilePending + ' total=' + total)
+  }
+})().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})
+`,
+    ['--expose-gc'],
+  )
+
+  t.is(status, 0, `expected exit 0, got status=${status} signal=${signal}\n${stderr}${stdout}`)
+  t.true(stdout.includes('total=40'), `unexpected output:\n${stdout}`)
+})
+
+test('encode() survives a resize that drops the old surface while the encode is in flight', async (t) => {
+  const { status, signal, stdout, stderr } = await runInChildProcess(`
+const { createCanvas } = require('./index.js')
+;(async () => {
+  for (let index = 0; index < 32; index += 1) {
+    const canvas = createCanvas(1024, 1024)
+    canvas.getContext('2d').fillRect(0, 0, 1024, 1024)
+    const promise = canvas.encode('png')
+    canvas.width = 512
+    await promise
+  }
+  console.log('done')
+})().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})
+`)
+
+  t.is(status, 0, `expected exit 0, got status=${status} signal=${signal}\n${stderr}${stdout}`)
+  t.true(stdout.includes('done'), `unexpected output:\n${stdout}`)
+})

--- a/load-image.js
+++ b/load-image.js
@@ -134,8 +134,12 @@ async function createImage(src, alt) {
 
   return new Promise((resolve, reject) => {
     image.onload = () => {
-      // Wait for bitmap decode before resolving
-      image.decode().then(() => resolve(image), reject)
+      // Wait for bitmap decode before resolving. SVG sources fire onload
+      // synchronously inside the src setter, where napi >= 3.12 rejects
+      // reentrant &mut borrows of the Image, so decode on a microtask.
+      Promise.resolve()
+        .then(() => image.decode())
+        .then(() => resolve(image), reject)
     }
     image.onerror = (e) => reject(e)
     image.src = src

--- a/skia-c/skia_c.cpp
+++ b/skia-c/skia_c.cpp
@@ -184,9 +184,18 @@ bool skiac_surface_save(skiac_surface* c_surface, const char* path) {
   return false;
 }
 
+void skiac_surface_ref(skiac_surface* c_surface) {
+  // SkSurface is ref counted.
+  if (c_surface) {
+    SURFACE_CAST->ref();
+  }
+}
+
 void skiac_surface_destroy(skiac_surface* c_surface) {
   // SkSurface is ref counted.
-  SURFACE_CAST->unref();
+  if (c_surface) {
+    SURFACE_CAST->unref();
+  }
 }
 
 skiac_surface* skiac_surface_copy_rgba(skiac_surface* c_surface,

--- a/skia-c/skia_c.hpp
+++ b/skia-c/skia_c.hpp
@@ -764,6 +764,7 @@ void skiac_surface_create_svg(skiac_svg_surface* c_surface,
                               uint32_t flag,
                               uint8_t cs);
 skiac_surface* skiac_surface_create_rgba(int width, int height, uint8_t cs);
+void skiac_surface_ref(skiac_surface* c_surface);
 void skiac_surface_destroy(skiac_surface* c_surface);
 skiac_surface* skiac_surface_copy_rgba(skiac_surface* c_surface,
                                        uint32_t x,

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -1952,6 +1952,54 @@ impl ObjectFinalize for CanvasRenderingContext2D {
   }
 }
 
+/// Source argument for `drawImage`. Wraps the `Either3` conversion so it runs
+/// in the generated callback glue inside the native borrow scope: napi-rs
+/// 3.12+ rejects `FromNapiValue` conversions performed inside a method body,
+/// and the wrapper keeps the custom error message.
+pub struct DrawImageSource<'a>(
+  pub Either3<&'a mut CanvasElement<'a>, &'a mut SVGCanvas<'a>, &'a mut Image>,
+);
+
+impl TypeName for DrawImageSource<'_> {
+  fn type_name() -> &'static str {
+    "CanvasElement | SVGCanvas | Image"
+  }
+
+  fn value_type() -> ValueType {
+    ValueType::Object
+  }
+}
+
+impl ValidateNapiValue for DrawImageSource<'_> {
+  unsafe fn validate(_env: sys::napi_env, _napi_val: sys::napi_value) -> Result<sys::napi_value> {
+    Ok(std::ptr::null_mut())
+  }
+}
+
+impl FromNapiValue for DrawImageSource<'static> {
+  unsafe fn from_napi_value(env: sys::napi_env, napi_val: sys::napi_value) -> Result<Self> {
+    match unsafe {
+      <Either3<&mut CanvasElement, &mut SVGCanvas, &mut Image> as FromNapiValue>::from_napi_value(
+        env, napi_val,
+      )
+    } {
+      Ok(value) => Ok(DrawImageSource(value)),
+      Err(_) => {
+        // Throw the TypeError eagerly: napi >= 3.12 no longer maps the
+        // InvalidArg status to a JS TypeError when synthesizing the error.
+        let _ = Env::from_raw(env).throw_type_error(
+          "Value is not one of these types: `CanvasElement`, `SVGCanvas`, `Image`",
+          Some("InvalidArg"),
+        );
+        Err(Error::new(
+          Status::InvalidArg,
+          "Value is not one of these types: `CanvasElement`, `SVGCanvas`, `Image`".to_string(),
+        ))
+      }
+    }
+  }
+}
+
 #[napi]
 impl CanvasRenderingContext2D {
   #[napi(constructor)]
@@ -2646,7 +2694,7 @@ impl CanvasRenderingContext2D {
   pub fn draw_image(
     &mut self,
     env: &Env,
-    image: Unknown,
+    image: DrawImageSource<'_>,
     sx: Option<f64>,
     sy: Option<f64>,
     s_width: Option<f64>,
@@ -2656,18 +2704,7 @@ impl CanvasRenderingContext2D {
     d_width: Option<f64>,
     d_height: Option<f64>,
   ) -> Result<()> {
-    let Ok(image) = (unsafe {
-      <Either3<&mut CanvasElement, &mut SVGCanvas, &mut Image> as FromNapiValue>::from_napi_value(
-        env.raw(),
-        image.raw(),
-      )
-    }) else {
-      return env.throw_type_error(
-        "Value is not one of these types: `CanvasElement`, `SVGCanvas`, `Image`",
-        Some("InvalidArg"),
-      );
-    };
-    let bitmap = match image {
+    let bitmap = match image.0 {
       Either3::A(canvas) => {
         // Flush the source canvas to render deferred operations before getting bitmap
         canvas.ctx.context.flush();

--- a/src/sk.rs
+++ b/src/sk.rs
@@ -418,6 +418,8 @@ pub mod ffi {
 
     pub fn skiac_surface_create_rgba(width: i32, height: i32, cs: u8) -> *mut skiac_surface;
 
+    pub fn skiac_surface_ref(surface: *mut skiac_surface);
+
     pub fn skiac_surface_destroy(surface: *mut skiac_surface);
 
     pub fn skiac_surface_copy_rgba(
@@ -2259,6 +2261,12 @@ impl Surface {
   }
 
   pub(crate) fn reference(&self) -> SurfaceRef {
+    // Take a new refcounted reference; released when the SurfaceRef drops.
+    if !self.ptr.is_null() {
+      unsafe {
+        ffi::skiac_surface_ref(self.ptr);
+      }
+    }
     SurfaceRef(self.ptr)
   }
 
@@ -2409,6 +2417,27 @@ impl SurfaceRef {
 
 unsafe impl Send for SurfaceRef {}
 unsafe impl Sync for SurfaceRef {}
+
+impl Clone for SurfaceRef {
+  fn clone(&self) -> Self {
+    if !self.0.is_null() {
+      unsafe {
+        ffi::skiac_surface_ref(self.0);
+      }
+    }
+    SurfaceRef(self.0)
+  }
+}
+
+impl Drop for SurfaceRef {
+  fn drop(&mut self) {
+    if !self.0.is_null() {
+      unsafe {
+        ffi::skiac_surface_destroy(self.0);
+      }
+    }
+  }
+}
 
 pub struct SurfaceData<'a> {
   slice: &'a [u8],


### PR DESCRIPTION
## Summary

Fixes #1312: `canvas.encode("png")` (and `toDataURLAsync`, `toBlob`, `convertToBlob`) crashed with a use-after-free when the JS canvas was garbage collected while the async encode was still running on the libuv threadpool. Bun crashed reliably; Node crashed too once the canvas was not held alive by a suspended async frame.

## Root cause

```text
JS thread                                libuv threadpool
──────────                               ────────────────
canvas.encode("png")
  └─> ContextData::Png(SurfaceRef) ────> compute(): encode surface
      SurfaceRef = raw pointer copy,
      no refcount taken

GC collects canvas (eager on Bun/JSC)
  └─> CanvasRenderingContext2D finalize
      └─> Drop(Context) → Drop(Surface)
          └─> skiac_surface_destroy() ══> refcount 0 → SkSurface freed
                                                       │
                                                    SEGFAULT
```

`Surface::reference()` returned a non-owning pointer copy of the Skia surface, which is owned solely by `CanvasRenderingContext2D` and freed by its finalizer. Nothing kept the surface (or the JS wrapper) alive while the task ran. The C++ shim already treats `SkSurface` as refcounted — it just never exposed `ref()`.

## Fix

- `skiac_surface_ref()` in the C shim (null-guarded, mirrors the existing `skiac_image_ref` convention; also null-guards `skiac_surface_destroy`).
- `SurfaceRef` is now owning: `Surface::reference()` bumps the refcount, `Clone` bumps it, `Drop` releases it. Zero changes at call sites — every async encode task keeps its surface alive until completion.
- Also makes encode safe across a `canvas.width = …` resize mid-encode (the old surface is no longer freed under the in-flight task).

## Verification

Repro from the issue (macOS/arm64, Node 24.19, Bun 1.3.14), before → after this change:

| Repro | Before (1.0.5) | After |
|---|---|---|
| `kick()` (canvas not held across await), 64×10, Node | SIGSEGV 5/5, exit 139 | all 10 rounds, exit 0 |
| original issue repro, Bun | SIGSEGV, exit 139 | all 10 rounds, exit 0 |
| forced GC mid-encode (FinalizationRegistry, n=8×5) | crash at n=8 | 40/40 wrappers finalized while in flight, all encodes resolve |
| resize during encode ×32 | — | resolves, exit 0 |

Test suite: `yarn ava -c 1` → 610 passed, 1 known failure (pre-existing `test.failing`), 13 skipped. Three new regression tests in `__test__/issue-1312-encode-gc.spec.ts` cover: encode with the canvas collectable mid-flight, forced GC while encodes are in flight, and encode racing a width change.

## Review notes

An adversarial review flagged that async encode still encodes a live, mutable surface — drawing after the `encode()` call (in particular full-canvas `clearRect`, which writes the surface directly) can be reflected in the encoded output. I verified this behavior: it is pre-existing and byte-for-byte identical on 1.0.5, and this PR neither introduces nor fixes it. Tracked separately as #1313 (call-time snapshot would be the fix there).

Cross-ref: oven-sh/bun#37917 (closed by Bun maintainers as an upstream canvas bug with the same root-cause analysis).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches native Skia refcounting on every async encode path; incorrect balance would leak or double-free surfaces, though the change mirrors existing image ref patterns and is covered by targeted crash regressions.
> 
> **Overview**
> Fixes **#1312** crashes when `encode()` / related async export runs after the JS canvas is collectable or the backing surface is replaced mid-flight.
> 
> **Async encode lifetime:** Adds `skiac_surface_ref` and makes `SurfaceRef` refcount-owning (`reference()`, `Clone`, `Drop`), so libuv encode tasks hold the Skia surface until they finish instead of dereferencing a freed pointer when the canvas finalizes or resizes.
> 
> **napi-rs 3.12 compatibility:** `loadImage` defers `image.decode()` to a microtask after `onload` so SVG’s synchronous `onload` does not re-enter the `Image` borrow. `drawImage` takes a `DrawImageSource` wrapper so `Either3` conversion runs in generated glue and invalid types still get an explicit `TypeError`.
> 
> **Tests:** New child-process regressions in `issue-1312-encode-gc.spec.ts` for unreferenced canvases across `await`, GC during encode (`--expose-gc`), and resize while encode is pending.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3203243dd4a6577e0591776554d7a9dc3c5f51f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->