### PR TITLE
perf: fast getImageData readback with runtime-dispatched SIMD unpremultiply

### DIFF
--- a/skia-c/skia_c.cpp
+++ b/skia-c/skia_c.cpp
@@ -246,6 +246,35 @@ void skiac_surface_read_pixels(skiac_surface* c_surface,
   }
 }
 
+bool skiac_surface_peek_premul_rgba(skiac_surface* c_surface,
+                                    skiac_peek_pixels* peek) {
+  SkPixmap pixmap;
+  if (!SURFACE_CAST->peekPixels(&pixmap) ||
+      pixmap.info().colorType() != SkColorType::kRGBA_8888_SkColorType ||
+      pixmap.info().alphaType() != SkAlphaType::kPremul_SkAlphaType) {
+    return false;
+  }
+  uint8_t cs;
+  if (SkColorSpace::Equals(pixmap.info().colorSpace(),
+                           SkColorSpace::MakeSRGB().get())) {
+    cs = 0;
+  } else if (SkColorSpace::Equals(
+                 pixmap.info().colorSpace(),
+                 SkColorSpace::MakeRGB(SkNamedTransferFn::kSRGB,
+                                       SkNamedGamut::kDisplayP3)
+                     .get())) {
+    cs = 1;
+  } else {
+    return false;
+  }
+  peek->ptr = static_cast<const uint8_t*>(pixmap.addr());
+  peek->row_bytes = pixmap.rowBytes();
+  peek->width = pixmap.width();
+  peek->height = pixmap.height();
+  peek->color_space = cs;
+  return true;
+}
+
 bool skiac_surface_read_pixels_rect(skiac_surface* c_surface,
                                     uint8_t* data,
                                     int x,
@@ -257,7 +286,8 @@ bool skiac_surface_read_pixels_rect(skiac_surface* c_surface,
   auto image_info =
       SkImageInfo::Make(w, h, SkColorType::kRGBA_8888_SkColorType,
                         SkAlphaType::kUnpremul_SkAlphaType, color_space);
-  auto result = SURFACE_CAST->readPixels(image_info, data, w * 4, x, y);
+  // size_t math: w * 4 would overflow int for very wide requests.
+  auto result = SURFACE_CAST->readPixels(image_info, data, (size_t)w * 4, x, y);
   return result;
 }
 

--- a/skia-c/skia_c.hpp
+++ b/skia-c/skia_c.hpp
@@ -784,6 +784,17 @@ bool skiac_surface_read_pixels_rect(skiac_surface* c_surface,
                                     int w,
                                     int h,
                                     uint8_t cs);
+// Direct access to a raster surface's pixels. Succeeds only for
+// premultiplied RGBA_8888 surfaces in sRGB (0) or Display P3 (1).
+struct skiac_peek_pixels {
+  const uint8_t* ptr;
+  size_t row_bytes;
+  int width;
+  int height;
+  uint8_t color_space;
+};
+bool skiac_surface_peek_premul_rgba(skiac_surface* c_surface,
+                                    skiac_peek_pixels* peek);
 void skiac_surface_png_data(skiac_surface* c_surface, skiac_sk_data* data);
 void skiac_surface_encode_data(skiac_surface* c_surface,
                                skiac_sk_data* data,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ pub mod picture_recorder;
 mod sk;
 mod state;
 pub mod svg;
+mod unpremul;
 
 const MIME_WEBP: &str = "image/webp";
 const MIME_PNG: &str = "image/png";

--- a/src/sk.rs
+++ b/src/sk.rs
@@ -157,6 +157,16 @@ pub mod ffi {
 
   #[repr(C)]
   #[derive(Copy, Clone, Debug)]
+  pub struct skiac_peek_pixels {
+    pub ptr: *const u8,
+    pub row_bytes: usize,
+    pub width: i32,
+    pub height: i32,
+    pub color_space: u8,
+  }
+
+  #[repr(C)]
+  #[derive(Copy, Clone, Debug)]
   pub struct skiac_sk_data {
     pub ptr: *mut u8,
     pub size: usize,
@@ -449,6 +459,11 @@ pub mod ffi {
       w: i32,
       h: i32,
       color_space: u8,
+    ) -> bool;
+
+    pub fn skiac_surface_peek_premul_rgba(
+      surface: *mut skiac_surface,
+      peek: *mut skiac_peek_pixels,
     ) -> bool;
 
     pub fn skiac_surface_png_data(surface: *mut skiac_surface, data: *mut skiac_sk_data);
@@ -2169,7 +2184,49 @@ impl Surface {
     height: u32,
     color_space: ColorSpace,
   ) -> Option<Vec<u8>> {
-    let mut result = vec![0; (width * height * 4) as usize];
+    // Reject requests whose dimensions or byte length cannot be represented,
+    // instead of letting the length wrap (32-bit targets) and Skia write past
+    // the allocation.
+    let len = width as u64 * height as u64 * 4;
+    if width > i32::MAX as u32 || height > i32::MAX as u32 || len > isize::MAX as u64 {
+      return None;
+    }
+    let len = len as usize;
+
+    // Fast path: fused SIMD unpremultiply straight from the surface pixels,
+    // when the CPU has a supported SIMD implementation (runtime-detected) and
+    // the surface is premultiplied RGBA in the requested color space.
+    if let Some(row_fn) = crate::unpremul::row_fn() {
+      let mut peek = ffi::skiac_peek_pixels {
+        ptr: ptr::null(),
+        row_bytes: 0,
+        width: 0,
+        height: 0,
+        color_space: 0,
+      };
+      if unsafe { ffi::skiac_surface_peek_premul_rgba(self.ptr, &mut peek) }
+        && peek.color_space == color_space as u8
+      {
+        return self.read_pixels_simd(&peek, row_fn, x, y, width, height, len);
+      }
+    }
+
+    // Skia conversion path (color space conversion, non-premultiplied
+    // surfaces, or no supported SIMD on this CPU).
+    // Skia clips the read rect against the surface bounds and only writes the
+    // intersecting region; per the canvas spec, pixels outside the surface
+    // must read as transparent black. Only zero-initialize when the requested
+    // rect is not fully contained in the surface; otherwise every byte is
+    // written by readPixels and the zeroing pass is wasted work.
+    let fully_contained = x >= 0
+      && y >= 0
+      && (x as u32).saturating_add(width) <= self.width()
+      && (y as u32).saturating_add(height) <= self.height();
+    let mut result = if fully_contained {
+      Vec::with_capacity(len)
+    } else {
+      vec![0; len]
+    };
     let status = unsafe {
       ffi::skiac_surface_read_pixels_rect(
         self.ptr,
@@ -2181,7 +2238,85 @@ impl Surface {
         color_space as u8,
       )
     };
-    if status { Some(result) } else { None }
+    if status {
+      // SAFETY: for a fully-contained rect readPixels writes all `len` bytes;
+      // for the clipped case the buffer was zero-initialized above.
+      unsafe { result.set_len(len) };
+      Some(result)
+    } else {
+      None
+    }
+  }
+
+  /// Fused readback + unpremultiply from a peeked premultiplied RGBA surface.
+  /// `len` is the validated `width * height * 4` from [`Self::read_pixels`].
+  #[allow(clippy::too_many_arguments)]
+  fn read_pixels_simd(
+    &self,
+    peek: &ffi::skiac_peek_pixels,
+    row_fn: crate::unpremul::RowFn,
+    x: i32,
+    y: i32,
+    width: u32,
+    height: u32,
+    len: usize,
+  ) -> Option<Vec<u8>> {
+    // Clip the requested rect against the surface bounds, same semantics as
+    // SkReadPixelsRec::trim: out-of-surface regions must read as transparent
+    // black (the buffer is zero-initialized below in that case) and a rect
+    // with no intersection fails. 64-bit math because x/y can be i32::MIN.
+    let mut src_x = x as i64;
+    let mut src_y = y as i64;
+    let mut copy_w = width as i64;
+    let mut copy_h = height as i64;
+    let mut dst_off_x = 0i64;
+    let mut dst_off_y = 0i64;
+    if src_x < 0 {
+      dst_off_x = -src_x;
+      copy_w += src_x;
+      src_x = 0;
+    }
+    if src_y < 0 {
+      dst_off_y = -src_y;
+      copy_h += src_y;
+      src_y = 0;
+    }
+    copy_w = copy_w.min(peek.width as i64 - src_x);
+    copy_h = copy_h.min(peek.height as i64 - src_y);
+    if copy_w <= 0 || copy_h <= 0 {
+      return None;
+    }
+    // Only zero-initialize when clipping leaves out-of-surface regions that
+    // must read as transparent black; a fully-contained read writes every
+    // byte and the zeroing pass is wasted work.
+    let fully_contained =
+      dst_off_x == 0 && dst_off_y == 0 && copy_w == width as i64 && copy_h == height as i64;
+    let mut result = if fully_contained {
+      Vec::with_capacity(len)
+    } else {
+      vec![0; len]
+    };
+    let src_stride = peek.row_bytes / 4;
+    let src_base = unsafe {
+      peek
+        .ptr
+        .add(src_y as usize * peek.row_bytes + src_x as usize * 4)
+        .cast::<u32>()
+    };
+    let dst_off = (dst_off_y * width as i64 + dst_off_x) as usize;
+    let dst_base = unsafe { result.as_mut_ptr().cast::<u32>().add(dst_off) };
+    // Derive each row pointer from the base instead of advancing past the
+    // final row, so no out-of-bounds pointer is ever formed.
+    for row in 0..copy_h as usize {
+      let src_row = unsafe { src_base.add(row * src_stride) };
+      let dst_row = unsafe { dst_base.add(row * width as usize) };
+      // SAFETY: both rows point at `copy_w` valid pixels; the freshly
+      // allocated dst never aliases the surface's src.
+      unsafe { row_fn(dst_row, src_row, copy_w as usize) };
+    }
+    // SAFETY: same argument as the Skia path above.
+    unsafe { result.set_len(len) };
+    Some(result)
   }
 
   pub fn data<'env>(&'env self) -> Option<SurfaceData<'env>> {

--- a/src/unpremul.rs
+++ b/src/unpremul.rs
@@ -1,0 +1,417 @@
+//! Fused premultiplied -> unpremultiplied RGBA row conversion for
+//! `getImageData` readbacks. x86_64 dispatches at runtime to the widest SIMD
+//! implementation the CPU supports (AVX2, then baseline SSE2); aarch64 uses
+//! NEON, which is mandatory in the base architecture.
+//!
+//! The float math matches Skia's conversion
+//! (skia/src/opts/SkSwizzler_opts.inc): normalized [0,1] space, guarded
+//! reciprocal of alpha (0 where alpha == 0), clamp to 255, round to nearest
+//! with ties to even (as Skia's SIMD paths do on both arm64 and x64).
+//!
+//! Targets without a matching implementation return `None` from [`row_fn`]
+//! and the caller falls back to Skia's own conversion through the C++ shim,
+//! keeping its exact rounding behavior there.
+
+use std::sync::OnceLock;
+
+/// Converts `n` pixels from premultiplied RGBA (`src`) to unpremultiplied
+/// RGBA (`dst`). `dst` must not alias `src`.
+pub type RowFn = unsafe fn(*mut u32, *const u32, usize);
+
+static ROW_FN: OnceLock<Option<RowFn>> = OnceLock::new();
+
+/// The widest row conversion this build's CPU supports, cached after the
+/// first call.
+pub fn row_fn() -> Option<RowFn> {
+  *ROW_FN.get_or_init(select_row_fn)
+}
+
+fn select_row_fn() -> Option<RowFn> {
+  #[cfg(target_arch = "x86_64")]
+  {
+    if std::arch::is_x86_feature_detected!("avx512f") {
+      return Some(avx512::row);
+    }
+    if std::arch::is_x86_feature_detected!("avx2") {
+      return Some(avx2::row);
+    }
+    // SSE2 is part of the x86_64 baseline, so this is always true; the check
+    // documents the requirement and costs nothing.
+    if std::arch::is_x86_feature_detected!("sse2") {
+      return Some(sse2::row);
+    }
+    None
+  }
+  #[cfg(target_arch = "aarch64")]
+  {
+    // NEON is mandatory in the AArch64 base architecture (macOS, Windows
+    // ARM64, Linux arm64 alike), so no runtime detection is needed.
+    Some(neon::row)
+  }
+  #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+  {
+    None
+  }
+}
+
+#[inline]
+fn unpremul_channel(reciprocal_a: f32, c: u32) -> u32 {
+  let v = (c as f32 * (1.0 / 255.0)) * reciprocal_a * 255.0;
+  v.min(255.0).round_ties_even() as u32
+}
+
+#[inline]
+fn unpremul_pixel(p: u32) -> u32 {
+  let a = p >> 24;
+  if a == 0 || a == 255 {
+    return p;
+  }
+  let reciprocal_a = 1.0 / (a as f32 * (1.0 / 255.0));
+  let r = unpremul_channel(reciprocal_a, p & 0xFF);
+  let g = unpremul_channel(reciprocal_a, (p >> 8) & 0xFF);
+  let b = unpremul_channel(reciprocal_a, (p >> 16) & 0xFF);
+  (a << 24) | (b << 16) | (g << 8) | r
+}
+
+/// Scalar loop for short rows that cannot fill a SIMD vector.
+unsafe fn row_scalar(dst: *mut u32, src: *const u32, n: usize) {
+  unsafe {
+    for i in 0..n {
+      dst.add(i).write(unpremul_pixel(src.add(i).read()));
+    }
+  }
+}
+
+#[cfg(target_arch = "aarch64")]
+pub mod neon {
+  use core::arch::aarch64::*;
+
+  #[inline]
+  fn unpremul_4(dst: *mut u32, src: *const u32) {
+    unsafe {
+      let p = vld1q_u32(src);
+      let a = vshrq_n_u32::<24>(p);
+      let a_zero = vceqq_u32(a, vdupq_n_u32(0));
+      // Fast path: vectors whose pixels are all fully opaque or fully
+      // transparent (the common case in real content) are copied as-is.
+      let fast = vorrq_u32(vceqq_u32(a, vdupq_n_u32(255)), a_zero);
+      if vminvq_u32(fast) == u32::MAX {
+        vst1q_u32(dst, p);
+        return;
+      }
+      let k1_255 = vdupq_n_f32(1.0 / 255.0);
+      let k255 = vdupq_n_f32(255.0);
+      let mask = vdupq_n_u32(0xFF);
+      let ra_raw = vdivq_f32(vdupq_n_f32(1.0), vmulq_f32(vcvtq_f32_u32(a), k1_255));
+      let ra = vreinterpretq_f32_u32(vbicq_u32(vreinterpretq_u32_f32(ra_raw), a_zero));
+      let channels = [
+        vandq_u32(p, mask),
+        vandq_u32(vshrq_n_u32::<8>(p), mask),
+        vandq_u32(vshrq_n_u32::<16>(p), mask),
+      ];
+      let mut converted = [vdupq_n_u32(0); 3];
+      for (slot, &c) in converted.iter_mut().zip(channels.iter()) {
+        let v = vmulq_f32(vcvtq_f32_u32(c), k1_255);
+        let v = vminq_f32(vmulq_f32(vmulq_f32(v, ra), k255), k255);
+        *slot = vcvtnq_u32_f32(v);
+      }
+      let out = vorrq_u32(
+        vshlq_n_u32::<24>(a),
+        vorrq_u32(
+          vshlq_n_u32::<16>(converted[2]),
+          vorrq_u32(vshlq_n_u32::<8>(converted[1]), converted[0]),
+        ),
+      );
+      vst1q_u32(dst, out);
+    }
+  }
+
+  /// # Safety
+  /// `dst` and `src` must each point to `n` valid pixels, and
+  /// `dst` must not alias `src`.
+  pub unsafe fn row(dst: *mut u32, src: *const u32, n: usize) {
+    let mut i = 0;
+    while i + 4 <= n {
+      unsafe { unpremul_4(dst.add(i), src.add(i)) };
+      i += 4;
+    }
+    if i < n {
+      if n >= 4 {
+        // Overlapping final vector; the conversion is idempotent and dst
+        // does not alias src, so re-converting a few pixels is safe.
+        unsafe { unpremul_4(dst.add(n - 4), src.add(n - 4)) };
+      } else {
+        unsafe { super::row_scalar(dst, src, n) };
+      }
+    }
+  }
+}
+
+#[cfg(target_arch = "x86_64")]
+pub mod sse2 {
+  use core::arch::x86_64::*;
+
+  #[inline]
+  fn unpremul_4(dst: *mut u32, src: *const u32) {
+    unsafe {
+      let p = _mm_loadu_si128(src.cast());
+      let a = _mm_srli_epi32::<24>(p);
+      let a_zero = _mm_cmpeq_epi32(a, _mm_setzero_si128());
+      // Fast path: vectors whose pixels are all fully opaque or fully
+      // transparent (the common case in real content) are copied as-is.
+      let fast = _mm_or_si128(_mm_cmpeq_epi32(a, _mm_set1_epi32(255)), a_zero);
+      if _mm_movemask_epi8(fast) == 0xFFFF {
+        _mm_storeu_si128(dst.cast(), p);
+        return;
+      }
+      let k1_255 = _mm_set1_ps(1.0 / 255.0);
+      let k255 = _mm_set1_ps(255.0);
+      let mask = _mm_set1_epi32(0xFF);
+      let ra_raw = _mm_div_ps(_mm_set1_ps(1.0), _mm_mul_ps(_mm_cvtepi32_ps(a), k1_255));
+      let ra = _mm_castsi128_ps(_mm_andnot_si128(a_zero, _mm_castps_si128(ra_raw)));
+      let channels = [
+        _mm_and_si128(p, mask),
+        _mm_and_si128(_mm_srli_epi32::<8>(p), mask),
+        _mm_and_si128(_mm_srli_epi32::<16>(p), mask),
+      ];
+      let mut converted = [_mm_setzero_si128(); 3];
+      for (slot, &c) in converted.iter_mut().zip(channels.iter()) {
+        let v = _mm_mul_ps(_mm_cvtepi32_ps(c), k1_255);
+        let v = _mm_min_ps(_mm_mul_ps(_mm_mul_ps(v, ra), k255), k255);
+        *slot = _mm_cvtps_epi32(v);
+      }
+      let out = _mm_or_si128(
+        _mm_slli_epi32::<24>(a),
+        _mm_or_si128(
+          _mm_slli_epi32::<16>(converted[2]),
+          _mm_or_si128(_mm_slli_epi32::<8>(converted[1]), converted[0]),
+        ),
+      );
+      _mm_storeu_si128(dst.cast(), out);
+    }
+  }
+
+  /// # Safety
+  /// `dst` and `src` must each point to `n` valid pixels, and
+  /// `dst` must not alias `src`.
+  pub unsafe fn row(dst: *mut u32, src: *const u32, n: usize) {
+    let mut i = 0;
+    while i + 4 <= n {
+      unsafe { unpremul_4(dst.add(i), src.add(i)) };
+      i += 4;
+    }
+    if i < n {
+      if n >= 4 {
+        // Overlapping final vector; the conversion is idempotent and dst
+        // does not alias src, so re-converting a few pixels is safe.
+        unsafe { unpremul_4(dst.add(n - 4), src.add(n - 4)) };
+      } else {
+        unsafe { super::row_scalar(dst, src, n) };
+      }
+    }
+  }
+}
+
+#[cfg(target_arch = "x86_64")]
+pub mod avx2 {
+  use core::arch::x86_64::*;
+
+  #[target_feature(enable = "avx2")]
+  unsafe fn unpremul_8(dst: *mut u32, src: *const u32) {
+    unsafe {
+      let p = _mm256_loadu_si256(src.cast());
+      let a = _mm256_srli_epi32::<24>(p);
+      let a_zero = _mm256_cmpeq_epi32(a, _mm256_setzero_si256());
+      // Fast path: vectors whose pixels are all fully opaque or fully
+      // transparent (the common case in real content) are copied as-is.
+      let fast = _mm256_or_si256(_mm256_cmpeq_epi32(a, _mm256_set1_epi32(255)), a_zero);
+      if _mm256_movemask_epi8(fast) == -1 {
+        _mm256_storeu_si256(dst.cast(), p);
+        return;
+      }
+      let k1_255 = _mm256_set1_ps(1.0 / 255.0);
+      let k255 = _mm256_set1_ps(255.0);
+      let mask = _mm256_set1_epi32(0xFF);
+      let ra_raw = _mm256_div_ps(
+        _mm256_set1_ps(1.0),
+        _mm256_mul_ps(_mm256_cvtepi32_ps(a), k1_255),
+      );
+      let ra = _mm256_castsi256_ps(_mm256_andnot_si256(a_zero, _mm256_castps_si256(ra_raw)));
+      let channels = [
+        _mm256_and_si256(p, mask),
+        _mm256_and_si256(_mm256_srli_epi32::<8>(p), mask),
+        _mm256_and_si256(_mm256_srli_epi32::<16>(p), mask),
+      ];
+      let mut converted = [_mm256_setzero_si256(); 3];
+      for (slot, &c) in converted.iter_mut().zip(channels.iter()) {
+        let v = _mm256_mul_ps(_mm256_cvtepi32_ps(c), k1_255);
+        let v = _mm256_min_ps(_mm256_mul_ps(_mm256_mul_ps(v, ra), k255), k255);
+        *slot = _mm256_cvtps_epi32(v);
+      }
+      let out = _mm256_or_si256(
+        _mm256_slli_epi32::<24>(a),
+        _mm256_or_si256(
+          _mm256_slli_epi32::<16>(converted[2]),
+          _mm256_or_si256(_mm256_slli_epi32::<8>(converted[1]), converted[0]),
+        ),
+      );
+      _mm256_storeu_si256(dst.cast(), out);
+    }
+  }
+
+  #[target_feature(enable = "avx2")]
+  unsafe fn row_impl(dst: *mut u32, src: *const u32, n: usize) {
+    unsafe {
+      let mut i = 0;
+      while i + 8 <= n {
+        unpremul_8(dst.add(i), src.add(i));
+        i += 8;
+      }
+      if i < n {
+        if n >= 8 {
+          // Overlapping final vector; the conversion is idempotent and dst
+          // does not alias src, so re-converting a few pixels is safe.
+          unpremul_8(dst.add(n - 8), src.add(n - 8));
+        } else {
+          super::sse2::row(dst, src, n);
+        }
+      }
+    }
+  }
+
+  /// # Safety
+  /// Requires AVX2 (runtime-detected by [`crate::unpremul::row_fn`]); `dst`
+  /// and `src` must each point to `n` valid pixels, and `dst` must not alias
+  /// `src`.
+  pub unsafe fn row(dst: *mut u32, src: *const u32, n: usize) {
+    unsafe { row_impl(dst, src, n) }
+  }
+}
+
+#[cfg(target_arch = "x86_64")]
+pub mod avx512 {
+  use core::arch::x86_64::*;
+
+  #[target_feature(enable = "avx512f")]
+  unsafe fn unpremul_16(dst: *mut u32, src: *const u32) {
+    unsafe {
+      let p = _mm512_loadu_si512(src.cast());
+      let a = _mm512_srli_epi32::<24>(p);
+      // Fast path: vectors whose pixels are all fully opaque or fully
+      // transparent (the common case in real content) are copied as-is.
+      let is_opaque = _mm512_cmpeq_epi32_mask(a, _mm512_set1_epi32(255));
+      let nonzero_a = _mm512_test_epi32_mask(a, a);
+      if (is_opaque | !nonzero_a) == 0xFFFF {
+        _mm512_storeu_si512(dst.cast(), p);
+        return;
+      }
+      let k1_255 = _mm512_set1_ps(1.0 / 255.0);
+      let k255 = _mm512_set1_ps(255.0);
+      let mask = _mm512_set1_epi32(0xFF);
+      let ra_raw = _mm512_div_ps(
+        _mm512_set1_ps(1.0),
+        _mm512_mul_ps(_mm512_cvtepi32_ps(a), k1_255),
+      );
+      // Guarded reciprocal of normalized alpha: 0 where alpha == 0 (as Skia).
+      let ra = _mm512_maskz_mov_ps(nonzero_a, ra_raw);
+      let channels = [
+        _mm512_and_si512(p, mask),
+        _mm512_and_si512(_mm512_srli_epi32::<8>(p), mask),
+        _mm512_and_si512(_mm512_srli_epi32::<16>(p), mask),
+      ];
+      let mut converted = [_mm512_setzero_si512(); 3];
+      for (slot, &c) in converted.iter_mut().zip(channels.iter()) {
+        let v = _mm512_mul_ps(_mm512_cvtepi32_ps(c), k1_255);
+        let v = _mm512_min_ps(_mm512_mul_ps(_mm512_mul_ps(v, ra), k255), k255);
+        *slot = _mm512_cvtps_epi32(v);
+      }
+      let out = _mm512_or_si512(
+        _mm512_slli_epi32::<24>(a),
+        _mm512_or_si512(
+          _mm512_slli_epi32::<16>(converted[2]),
+          _mm512_or_si512(_mm512_slli_epi32::<8>(converted[1]), converted[0]),
+        ),
+      );
+      _mm512_storeu_si512(dst.cast(), out);
+    }
+  }
+
+  #[target_feature(enable = "avx512f")]
+  unsafe fn row_impl(dst: *mut u32, src: *const u32, n: usize) {
+    unsafe {
+      let mut i = 0;
+      while i + 16 <= n {
+        unpremul_16(dst.add(i), src.add(i));
+        i += 16;
+      }
+      if i < n {
+        if n >= 16 {
+          // Overlapping final vector; the conversion is idempotent and dst
+          // does not alias src, so re-converting a few pixels is safe.
+          unpremul_16(dst.add(n - 16), src.add(n - 16));
+        } else {
+          super::avx2::row(dst, src, n);
+        }
+      }
+    }
+  }
+
+  /// # Safety
+  /// Requires AVX-512F (runtime-detected by [`crate::unpremul::row_fn`]);
+  /// `dst` and `src` must each point to `n` valid pixels, and `dst` must not
+  /// alias `src`.
+  pub unsafe fn row(dst: *mut u32, src: *const u32, n: usize) {
+    unsafe { row_impl(dst, src, n) }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  // Reference: per-pixel float math identical to the scalar helpers.
+  fn reference_row(dst: &mut [u32], src: &[u32]) {
+    for (d, &s) in dst.iter_mut().zip(src.iter()) {
+      *d = super::unpremul_pixel(s);
+    }
+  }
+
+  fn check(row: unsafe fn(*mut u32, *const u32, usize)) {
+    // All alpha values x several channel values (only valid premultiplied
+    // combinations: channel <= alpha, which surface content always
+    // satisfies), plus row lengths exercising the vector loop, the
+    // overlapping tail, and the short-row scalar path.
+    let mut src = Vec::new();
+    for a in 0u32..=255 {
+      for c in [0u32, 1, 5, 127, 128, 200, 254, 255] {
+        let c = c.min(a);
+        src.push((a << 24) | (c << 16) | (c << 8) | c);
+      }
+    }
+    for n in [1usize, 2, 3, 4, 5, 7, 8, 9, 15, 16, 17, 63, 64, src.len()] {
+      let mut expected = vec![0u32; n];
+      let mut actual = vec![0u32; n];
+      reference_row(&mut expected, &src[..n]);
+      unsafe { row(actual.as_mut_ptr(), src.as_ptr(), n) };
+      assert_eq!(actual, expected, "row conversion mismatch at n={n}");
+    }
+  }
+
+  #[test]
+  fn simd_matches_scalar() {
+    #[cfg(target_arch = "x86_64")]
+    {
+      if std::arch::is_x86_feature_detected!("sse2") {
+        check(super::sse2::row);
+      }
+      if std::arch::is_x86_feature_detected!("avx2") {
+        check(super::avx2::row);
+      }
+      if std::arch::is_x86_feature_detected!("avx512f") {
+        check(super::avx512::row);
+      }
+    }
+    #[cfg(target_arch = "aarch64")]
+    {
+      check(super::neon::row);
+    }
+  }
+}


### PR DESCRIPTION
Closes #1318.

## Root cause

`getImageData` readbacks went through Skia's generic pixel conversion (`SkConvertPixels`), which unpremultiplies **every** pixel with per-pixel float division, and the Rust side additionally zero-initialized the output buffer before each read. node-canvas wins by skipping all math for fully opaque/transparent pixels — which dominate real content — with a scalar per-pixel branch.

## Approach

- Peek the premultiplied RGBA surface directly (`skiac_surface_peek_premul_rgba`) and unpremultiply with a fused SIMD loop (`src/unpremul.rs`):
  - **x86_64**: runtime detection (cached in a `OnceLock`) — AVX-512F (16 px/iter) → AVX2 (8 px/iter) → SSE2 (4 px/iter, x86_64 baseline)
  - **aarch64**: NEON (4 px/iter), selected at compile time — NEON is mandatory in the AArch64 base architecture
  - Vectors whose pixels are all fully opaque or fully transparent are copied as-is; the rest take the same float math Skia uses (normalized [0,1], guarded reciprocal, round-to-nearest-even).
- Skip zero-initializing the output buffer when the read rect is fully contained in the surface; clipped reads still zero-fill so out-of-surface regions read as transparent black per spec.
- CPUs without a matching SIMD implementation (armv7, riscv64) and color-space-converting reads keep Skia's conversion path and its exact rounding behavior.
- Hardening: reject read requests whose dimensions/byte length can't be represented (32-bit length wrap), clip in 64-bit math (INT_MIN coordinates), per-row pointer derivation (no out-of-bounds pointer arithmetic), and `size_t` row stride in the C++ fallback.

## Benchmarks (issue's repro script, M-series Mac, median of 30)

| size | before | after | node-canvas |
|---|---:|---:|---:|
| 854x480 | 0.30 ms | **0.13 ms** | 0.29 ms |
| 1280x720 | 0.66 ms | **0.27 ms** | 0.62 ms |
| 1920x1080 | 1.48 ms | **0.61 ms** | 1.09 ms |
| 3840x2160 | 6.13 ms | **2.63 ms** | 4.90 ms |

## x86_64 verification (Cloudflare sandbox, AMD EPYC with AVX-512F)

All three x86 tiers pass exhaustive correctness: every one of the 65536 valid (alpha, channel) combinations must re-premultiply to the exact input and match the scalar reference bit-for-bit, plus row-length edge cases (vector loop, overlapping tail, short rows).

Raw conversion throughput, median of 30 (opaque = fast path everywhere; translucent = no fast-path vectors):

| content | size | scalar | SSE2 | AVX2 | AVX-512 |
|---|---|---:|---:|---:|---:|
| opaque | 1920x1080 | 1.25 ms | 0.45 ms | 0.23 ms | 0.23 ms |
| translucent | 1920x1080 | 22.5 ms | 2.22 ms | 1.05 ms | **0.83 ms** |
| opaque | 3840x2160 | 4.88 ms | 2.25 ms | 1.56 ms | 1.60 ms |
| translucent | 3840x2160 | 172.6 ms | 9.07 ms | 4.18 ms | **3.11 ms** |

AVX-512 is ~21–26% faster than AVX2 on translucent content and at parity on opaque (memory-bound).

## Correctness

- `getImageData` output is **byte-identical** to the previous build (SHA-256 over translucent gradients, anti-aliased text, odd-size sub-rects, out-of-bounds reads).
- Rust unit test: SIMD output matches the scalar reference for all 256 alpha values and every row-length edge case.
- Full ava suite: 610 passed.