### PR TITLE
fix: capture call-time snapshot in async encode APIs (#1313)

### DIFF
--- a/__test__/issue-1313-encode-snapshot.spec.ts
+++ b/__test__/issue-1313-encode-snapshot.spec.ts
@@ -1,0 +1,250 @@
+import { pbkdf2 } from 'node:crypto'
+
+import test from 'ava'
+
+import { createCanvas, loadImage } from '../index.js'
+
+// Occupy every libuv worker so the async encode task is queued behind them
+// and cannot start before the main thread mutates the canvas.
+function occupyThreadpool(count = 8): Promise<unknown>[] {
+  return Array.from(
+    { length: count },
+    () =>
+      new Promise((resolve, reject) => {
+        pbkdf2('a', 'b', 1_000_000, 32, 'sha512', (err, key) => (err ? reject(err) : resolve(key)))
+      }),
+  )
+}
+
+function drawRed(ctx: ReturnType<ReturnType<typeof createCanvas>['getContext']>) {
+  ctx.fillStyle = 'red'
+  ctx.fillRect(0, 0, 256, 256)
+}
+
+// https://github.com/Brooooooklyn/canvas/issues/1313
+// Async encode must capture the bitmap at call time; drawing after the call
+// must not change the encoded output.
+
+test('encode(png) snapshots pixels at call time', async (t) => {
+  const canvas = createCanvas(256, 256)
+  const ctx = canvas.getContext('2d')
+  drawRed(ctx)
+  const expected = canvas.encodeSync('png')
+
+  const occupiers = occupyThreadpool()
+  const promise = canvas.encode('png')
+  ctx.clearRect(0, 0, 256, 256)
+  const [output] = await Promise.all([promise, ...occupiers])
+
+  t.true(
+    output.equals(expected),
+    'PNG must encode the red bitmap captured at call time, not the cleared surface',
+  )
+})
+
+test('encode(jpeg) snapshots pixels at call time', async (t) => {
+  const canvas = createCanvas(256, 256)
+  const ctx = canvas.getContext('2d')
+  drawRed(ctx)
+  const expected = canvas.encodeSync('jpeg', 92)
+
+  const occupiers = occupyThreadpool()
+  const promise = canvas.encode('jpeg', 92)
+  ctx.clearRect(0, 0, 256, 256)
+  const [output] = await Promise.all([promise, ...occupiers])
+
+  t.true(output.equals(expected), 'JPEG must encode the bitmap captured at call time')
+})
+
+test('encode(webp) snapshots pixels at call time', async (t) => {
+  const canvas = createCanvas(256, 256)
+  const ctx = canvas.getContext('2d')
+  drawRed(ctx)
+  const expected = canvas.encodeSync('webp', 92)
+
+  const occupiers = occupyThreadpool()
+  const promise = canvas.encode('webp', 92)
+  ctx.clearRect(0, 0, 256, 256)
+  const [output] = await Promise.all([promise, ...occupiers])
+
+  t.true(output.equals(expected), 'WebP must encode the bitmap captured at call time')
+})
+
+test('encode(gif) snapshots pixels at call time', async (t) => {
+  const canvas = createCanvas(256, 256)
+  const ctx = canvas.getContext('2d')
+  drawRed(ctx)
+  const expected = canvas.encodeSync('gif')
+
+  const occupiers = occupyThreadpool()
+  const promise = canvas.encode('gif')
+  ctx.clearRect(0, 0, 256, 256)
+  const [output] = await Promise.all([promise, ...occupiers])
+
+  t.true(output.equals(expected), 'GIF must encode the bitmap captured at call time')
+})
+
+test('encode(avif) snapshots pixels at call time', async (t) => {
+  const canvas = createCanvas(256, 256)
+  const ctx = canvas.getContext('2d')
+
+  // A fully transparent reference: with the bug, the post-call clearRect
+  // leaks into the output and the bytes match this transparent encode.
+  const transparent = createCanvas(256, 256)
+  const transparentBytes = transparent.encodeSync('avif')
+
+  drawRed(ctx)
+  const occupiers = occupyThreadpool()
+  const promise = canvas.encode('avif')
+  ctx.clearRect(0, 0, 256, 256)
+  const [output] = await Promise.all([promise, ...occupiers])
+
+  t.false(
+    output.equals(transparentBytes),
+    'AVIF must not reflect the clearRect that happened after encode() was called',
+  )
+})
+
+test('toDataURLAsync snapshots pixels at call time', async (t) => {
+  const canvas = createCanvas(256, 256)
+  const ctx = canvas.getContext('2d')
+  drawRed(ctx)
+  const expected = canvas.toDataURL('image/png')
+
+  const occupiers = occupyThreadpool()
+  const promise = canvas.toDataURLAsync('image/png')
+  ctx.clearRect(0, 0, 256, 256)
+  const [output] = await Promise.all([promise, ...occupiers])
+
+  t.is(output, expected, 'toDataURLAsync must encode the bitmap captured at call time')
+})
+
+test('toBlob snapshots pixels at call time', async (t) => {
+  const canvas = createCanvas(256, 256)
+  const ctx = canvas.getContext('2d')
+  drawRed(ctx)
+  const expected = canvas.encodeSync('png')
+
+  const occupiers = occupyThreadpool()
+  const promise = new Promise<Buffer>((resolve, reject) => {
+    canvas.toBlob(
+      (blob) =>
+        blob
+          ? blob.arrayBuffer().then((buf) => resolve(Buffer.from(buf)))
+          : reject(new Error('toBlob callback received null')),
+      'image/png',
+    )
+  })
+  ctx.clearRect(0, 0, 256, 256)
+  const [output] = await Promise.all([promise, ...occupiers])
+
+  t.true(output.equals(expected), 'toBlob must encode the bitmap captured at call time')
+})
+
+test('convertToBlob snapshots pixels at call time', async (t) => {
+  const canvas = createCanvas(256, 256)
+  const ctx = canvas.getContext('2d')
+  drawRed(ctx)
+  const expected = canvas.encodeSync('png')
+
+  const occupiers = occupyThreadpool()
+  const promise = canvas.convertToBlob()
+  ctx.clearRect(0, 0, 256, 256)
+  const [blob] = await Promise.all([promise, ...occupiers])
+  const output = Buffer.from(await blob.arrayBuffer())
+
+  t.true(output.equals(expected), 'convertToBlob must encode the bitmap captured at call time')
+})
+
+// Drawing after encode() (not just clearRect) must also be excluded: ordinary
+// draws are deferred in the PageRecorder and materialize on the next flush,
+// which used to happen on the live surface the worker was encoding.
+test('encode(png) excludes draws made after the call', async (t) => {
+  const canvas = createCanvas(256, 256)
+  const ctx = canvas.getContext('2d')
+  drawRed(ctx)
+  const expected = canvas.encodeSync('png')
+
+  const occupiers = occupyThreadpool()
+  const promise = canvas.encode('png')
+  ctx.fillStyle = 'blue'
+  ctx.fillRect(0, 0, 256, 256)
+  const [output] = await Promise.all([promise, ...occupiers])
+
+  t.true(output.equals(expected), 'PNG must not include the blue fill drawn after encode()')
+})
+
+// canvas.data() must hand JS an owned copy: writing through a zero-copy view
+// of the surface would bypass Skia's copy-on-write and corrupt snapshots
+// already captured by a queued encode.
+test('encode(png) is isolated from canvas.data() mutation', async (t) => {
+  const canvas = createCanvas(256, 256)
+  const ctx = canvas.getContext('2d')
+  drawRed(ctx)
+  const expected = canvas.encodeSync('png')
+
+  const occupiers = occupyThreadpool()
+  const promise = canvas.encode('png')
+  canvas.data().fill(0)
+  const [output] = await Promise.all([promise, ...occupiers])
+
+  t.true(
+    output.equals(expected),
+    'PNG must not reflect writes through canvas.data() made after encode()',
+  )
+})
+
+test('canvas.data() returns pixel bytes that are detached from the surface', (t) => {
+  const canvas = createCanvas(4, 4)
+  const ctx = canvas.getContext('2d')
+  ctx.fillStyle = 'red'
+  ctx.fillRect(0, 0, 4, 4)
+
+  const data = canvas.data()
+  t.deepEqual(Array.from(data.subarray(0, 4)), [255, 0, 0, 255])
+
+  data.fill(0)
+  t.deepEqual(
+    Array.from(canvas.data().subarray(0, 4)),
+    [255, 0, 0, 255],
+    'mutating the returned buffer must not change the surface',
+  )
+})
+
+async function decodeCenterPixel(buf: Buffer): Promise<number[]> {
+  const image = await loadImage(buf)
+  const canvas = createCanvas(64, 64)
+  const ctx = canvas.getContext('2d')
+  ctx.drawImage(image, 0, 0)
+  return Array.from(ctx.getImageData(32, 32, 1, 1).data)
+}
+
+// GIF collapses alpha to opaque/transparent, so it must receive straight
+// (non-premultiplied) RGB: feeding premultiplied bytes bakes the darkened
+// color in as an opaque pixel.
+test('gif encodes translucent colors from straight RGB', async (t) => {
+  const canvas = createCanvas(64, 64)
+  const ctx = canvas.getContext('2d')
+  ctx.fillStyle = 'rgba(20,200,100,0.25)'
+  ctx.fillRect(0, 0, 64, 64)
+
+  const [r, g, b, a] = await decodeCenterPixel(canvas.encodeSync('gif'))
+  t.true(Math.abs(r - 20) <= 10, `red channel ${r}, expected ~20`)
+  t.true(Math.abs(g - 200) <= 10, `green channel ${g}, expected ~200`)
+  t.true(Math.abs(b - 100) <= 10, `blue channel ${b}, expected ~100`)
+  t.is(a, 255, 'non-zero alpha collapses to opaque in GIF')
+})
+
+// AVIF keeps alpha; in-library decode must round-trip the translucent color.
+test('avif round-trips translucent colors', async (t) => {
+  const canvas = createCanvas(64, 64)
+  const ctx = canvas.getContext('2d')
+  ctx.fillStyle = 'rgba(20,200,100,0.25)'
+  ctx.fillRect(0, 0, 64, 64)
+
+  const [r, g, b, a] = await decodeCenterPixel(canvas.encodeSync('avif'))
+  t.true(Math.abs(r - 20) <= 12, `red channel ${r}, expected ~20`)
+  t.true(Math.abs(g - 200) <= 12, `green channel ${g}, expected ~200`)
+  t.true(Math.abs(b - 100) <= 12, `blue channel ${b}, expected ~100`)
+  t.true(Math.abs(a - 64) <= 12, `alpha channel ${a}, expected ~64`)
+})

--- a/skia-c/skia_c.cpp
+++ b/skia-c/skia_c.cpp
@@ -1998,6 +1998,53 @@ int skiac_image_get_height(skiac_image* c_image) {
   return c_image ? IMAGE_CAST->height() : 0;
 }
 
+// Encodes the image directly; the caller keeps ownership of c_image.
+void skiac_image_encode_data(skiac_image* c_image,
+                             skiac_sk_data* data,
+                             int format,
+                             int quality) {
+  auto image = IMAGE_CAST;
+  sk_sp<SkData> encoded_data;
+  if (format == int(SkEncodedImageFormat::kJPEG)) {
+    SkJpegEncoder::Options options;
+    options.fQuality = quality;
+    encoded_data = SkJpegEncoder::Encode(nullptr, image, options);
+  } else if (format == int(SkEncodedImageFormat::kPNG)) {
+    encoded_data =
+        SkPngEncoder::Encode(nullptr, image, SkPngEncoder::Options());
+  } else if (format == int(SkEncodedImageFormat::kWEBP)) {
+    SkWebpEncoder::Options options;
+    options.fCompression = quality == 100
+                               ? SkWebpEncoder::Compression::kLossless
+                               : SkWebpEncoder::Compression::kLossy;
+    options.fQuality = quality == 100 ? 75 : quality;
+    encoded_data = SkWebpEncoder::Encode(nullptr, image, options);
+  }
+  if (encoded_data) {
+    data->ptr = const_cast<uint8_t*>(encoded_data->bytes());
+    data->size = encoded_data->size();
+    data->data = reinterpret_cast<skiac_data*>(encoded_data.release());
+  }
+}
+
+bool skiac_image_read_pixels(skiac_image* c_image,
+                             uint8_t* dst,
+                             size_t row_bytes,
+                             int alpha_type) {
+  if (!c_image || !dst) {
+    return false;
+  }
+  if (alpha_type != int(kPremul_SkAlphaType) &&
+      alpha_type != int(kUnpremul_SkAlphaType)) {
+    return false;
+  }
+  auto image = IMAGE_CAST;
+  auto info = SkImageInfo::Make(
+      image->width(), image->height(), kRGBA_8888_SkColorType,
+      static_cast<SkAlphaType>(alpha_type), image->refColorSpace());
+  return image->readPixels(nullptr, info, dst, row_bytes, 0, 0);
+}
+
 void skiac_canvas_draw_sk_image(skiac_canvas* c_canvas,
                                 skiac_image* c_image,
                                 float left,

--- a/skia-c/skia_c.hpp
+++ b/skia-c/skia_c.hpp
@@ -1185,6 +1185,14 @@ void skiac_image_ref(skiac_image* c_image);
 void skiac_image_destroy(skiac_image* c_image);
 int skiac_image_get_width(skiac_image* c_image);
 int skiac_image_get_height(skiac_image* c_image);
+void skiac_image_encode_data(skiac_image* c_image,
+                             skiac_sk_data* data,
+                             int format,
+                             int quality);
+bool skiac_image_read_pixels(skiac_image* c_image,
+                             uint8_t* dst,
+                             size_t row_bytes,
+                             int alpha_type);
 void skiac_canvas_draw_sk_image(skiac_canvas* c_canvas,
                                 skiac_image* c_image,
                                 float left,

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -2,7 +2,6 @@ use std::cell::RefCell;
 use std::f32::consts::PI;
 use std::mem;
 use std::result;
-use std::slice;
 use std::str::FromStr;
 use std::sync::LazyLock;
 
@@ -34,7 +33,7 @@ use crate::{
   sk::{
     AlphaType, Bitmap, BlendMode, ColorSpace, FillType, FontVariantCaps, ImageFilter, LineMetrics,
     MaskFilter, Matrix, Paint, PaintStyle, Path as SkPath, PathEffect, PathOp,
-    SkEncodedImageFormat, SkWMemoryStream, SkiaDataRef, Surface, SurfaceRef, Transform,
+    SkEncodedImageFormat, SkImage, SkWMemoryStream, SkiaDataRef, Surface, Transform,
   },
   state::Context2dRenderingState,
 };
@@ -3496,11 +3495,11 @@ impl From<Transform> for TransformObject {
 }
 
 pub enum ContextData {
-  Png(SurfaceRef),
-  Jpeg(SurfaceRef, u8),
-  Webp(SurfaceRef, u8),
-  Avif(SurfaceRef, Config, u32, u32),
-  Gif(SurfaceRef, GifConfig, u32, u32),
+  Png(SkImage),
+  Jpeg(SkImage, u8),
+  Webp(SkImage, u8),
+  Avif(SkImage, Config, u32, u32),
+  Gif(SkImage, GifConfig, u32, u32),
 }
 
 pub enum ContextOutputData {
@@ -3542,8 +3541,8 @@ impl ContextOutputData {
 #[inline]
 pub(crate) fn encode_surface(data: &ContextData) -> Result<ContextOutputData> {
   match data {
-    ContextData::Png(surface) => surface
-      .png_data()
+    ContextData::Png(image) => image
+      .encode_data(SkEncodedImageFormat::Png, 100)
       .map(ContextOutputData::Skia)
       .ok_or_else(|| {
         Error::new(
@@ -3551,7 +3550,7 @@ pub(crate) fn encode_surface(data: &ContextData) -> Result<ContextOutputData> {
           "Get png data from surface failed".to_string(),
         )
       }),
-    ContextData::Jpeg(surface, quality) => surface
+    ContextData::Jpeg(image, quality) => image
       .encode_data(SkEncodedImageFormat::Jpeg, *quality)
       .map(ContextOutputData::Skia)
       .ok_or_else(|| {
@@ -3560,7 +3559,7 @@ pub(crate) fn encode_surface(data: &ContextData) -> Result<ContextOutputData> {
           "Get jpeg data from surface failed".to_string(),
         )
       }),
-    ContextData::Webp(surface, quality) => surface
+    ContextData::Webp(image, quality) => image
       .encode_data(SkEncodedImageFormat::Webp, *quality)
       .map(ContextOutputData::Skia)
       .ok_or_else(|| {
@@ -3569,29 +3568,32 @@ pub(crate) fn encode_surface(data: &ContextData) -> Result<ContextOutputData> {
           "Get webp data from surface failed".to_string(),
         )
       }),
-    ContextData::Avif(surface, config, width, height) => surface
-      .data()
+    ContextData::Avif(image, config, width, height) => image
+      .read_pixels(AlphaType::Unpremultiplied)
       .ok_or_else(|| {
         Error::new(
           Status::GenericFailure,
           "Get avif data from surface failed".to_string(),
         )
       })
-      .and_then(|(data, size)| {
-        crate::avif::encode(
-          unsafe { slice::from_raw_parts(data, size) },
-          *width,
-          *height,
-          config,
-        )
-        .map(ContextOutputData::Avif)
-        .map_err(|e| Error::new(Status::GenericFailure, format!("{e}")))
+      .and_then(|pixels| {
+        crate::avif::encode(&pixels, *width, *height, config)
+          .map(ContextOutputData::Avif)
+          .map_err(|e| Error::new(Status::GenericFailure, format!("{e}")))
       }),
-    ContextData::Gif(surface, config, width, height) => {
-      crate::gif::encode_surface(surface, *width, *height, config)
-        .map(ContextOutputData::Gif)
-        .map_err(|e| Error::new(Status::GenericFailure, format!("{e}")))
-    }
+    ContextData::Gif(image, config, width, height) => image
+      .read_pixels(AlphaType::Unpremultiplied)
+      .ok_or_else(|| {
+        Error::new(
+          Status::GenericFailure,
+          "Get gif data from surface failed".to_string(),
+        )
+      })
+      .and_then(|pixels| {
+        crate::gif::encode(&pixels, *width, *height, config)
+          .map(ContextOutputData::Gif)
+          .map_err(|e| Error::new(Status::GenericFailure, format!("{e}")))
+      }),
   }
 }
 

--- a/src/gif.rs
+++ b/src/gif.rs
@@ -3,7 +3,6 @@ use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
 use crate::error::SkError;
-use crate::sk::SurfaceRef;
 
 /// GIF encoding configuration for single-frame encoding
 #[napi(object)]
@@ -299,19 +298,4 @@ pub(crate) fn encode(
   }
 
   Ok(buffer)
-}
-
-/// Encode a surface reference as a static GIF
-pub(crate) fn encode_surface(
-  surface: &SurfaceRef,
-  width: u32,
-  height: u32,
-  config: &GifConfig,
-) -> std::result::Result<Vec<u8>, SkError> {
-  let (data, size) = surface
-    .data()
-    .ok_or_else(|| SkError::Generic("Failed to get surface pixels for GIF encoding".to_owned()))?;
-
-  let pixels = unsafe { std::slice::from_raw_parts(data, size) };
-  encode(pixels, width, height, config)
 }

--- a/src/image.rs
+++ b/src/image.rs
@@ -1056,7 +1056,8 @@ impl<'env> ScopedTask<'env> for BitmapDecoder {
         avif_image.row_bytes as usize,
         (avif_image.row_bytes * avif_image.height) as usize,
         ColorType::RGBA8888,
-        AlphaType::Premultiplied,
+        // libavif's avifImageYUVToRGB outputs straight (non-premultiplied) alpha.
+        AlphaType::Unpremultiplied,
       );
       DecodeStatus::Ok(BitmapInfo {
         data: bitmap,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,6 @@ use std::{
 use napi::{
   Property, ScopedTask,
   bindgen_prelude::*,
-  noop_finalize,
   tokio::sync::mpsc::{channel, error::TrySendError},
   tokio_stream::wrappers::ReceiverStream,
 };
@@ -29,7 +28,7 @@ use ctx::{
   STROKE_STYLE_HIDDEN_NAME, SvgExportFlag, encode_surface,
 };
 use font::{FONT_REGEXP, init_font_regexp};
-use sk::{ColorSpace, SkiaDataRef, SurfaceRef};
+use sk::{AlphaType, ColorSpace, SkImage, SkiaDataRef};
 
 use avif::AvifConfig;
 
@@ -253,8 +252,19 @@ impl<'c> CanvasElement<'c> {
     // Flush deferred rendering before encoding
     self.ctx.context.flush();
     let mime = mime.as_str();
+    let image = self
+      .ctx
+      .context
+      .surface
+      .make_image_snapshot()
+      .ok_or_else(|| {
+        Error::new(
+          Status::GenericFailure,
+          "Create image snapshot failed".to_owned(),
+        )
+      })?;
     let context_data = get_data_ref(
-      &self.ctx.context.surface.reference(),
+      &image,
       mime,
       &match quality_or_config {
         Either3::A(q) => Either::A(q),
@@ -296,7 +306,7 @@ impl<'c> CanvasElement<'c> {
   }
 
   #[napi]
-  pub fn data<'env>(&mut self, env: Env) -> Result<BufferSlice<'env>> {
+  pub fn data(&mut self) -> Result<Buffer> {
     // Flush deferred rendering before reading data
     self.ctx.context.flush();
     let ctx2d = &self.ctx.context;
@@ -309,7 +319,9 @@ impl<'c> CanvasElement<'c> {
         "Get png data from surface failed".to_string(),
       )
     })?;
-    unsafe { BufferSlice::from_external(&env, ptr.cast_mut(), size, 0, noop_finalize) }
+    // Copy the pixels: exposing the live surface buffer would let JS writes
+    // bypass Skia's copy-on-write and corrupt in-flight encode snapshots.
+    Ok(unsafe { slice::from_raw_parts(ptr, size) }.to_vec().into())
   }
 
   #[napi(js_name = "toDataURLAsync")]
@@ -346,7 +358,17 @@ impl<'c> CanvasElement<'c> {
   ) -> Result<()> {
     // Flush deferred rendering before encoding
     self.ctx.context.flush();
-    let surface_data = self.ctx.context.surface.reference();
+    let image = self
+      .ctx
+      .context
+      .surface
+      .make_image_snapshot()
+      .ok_or_else(|| {
+        Error::new(
+          Status::GenericFailure,
+          "Create image snapshot failed".to_owned(),
+        )
+      })?;
     let mime = mime.unwrap_or_else(|| MIME_PNG.to_owned());
     let quality_value = quality.unwrap_or(0.92).clamp(0.0, 1.0);
     let quality_or_config = if mime == MIME_AVIF {
@@ -362,7 +384,7 @@ impl<'c> CanvasElement<'c> {
     let callback_ref = Rc::new(callback.create_ref()?);
     let callback_ref_in_catch = callback_ref.clone();
     let async_blob_task = AsyncBlob {
-      surface_ref: surface_data,
+      image,
       mime,
       quality_or_config,
       width,
@@ -387,9 +409,23 @@ impl<'c> CanvasElement<'c> {
   }
 
   #[napi]
-  pub fn convert_to_blob(&mut self, options: Option<ConvertToBlobOptions>) -> AsyncTask<AsyncBlob> {
+  pub fn convert_to_blob(
+    &mut self,
+    options: Option<ConvertToBlobOptions>,
+  ) -> Result<AsyncTask<AsyncBlob>> {
     // Flush deferred rendering before encoding
     self.ctx.context.flush();
+    let image = self
+      .ctx
+      .context
+      .surface
+      .make_image_snapshot()
+      .ok_or_else(|| {
+        Error::new(
+          Status::GenericFailure,
+          "Create image snapshot failed".to_owned(),
+        )
+      })?;
     let options = options.unwrap_or_default();
     let mime = options.mime.unwrap_or_else(|| MIME_PNG.to_owned());
     let quality = options.quality.unwrap_or(0.92).clamp(0.0, 1.0);
@@ -401,13 +437,13 @@ impl<'c> CanvasElement<'c> {
     } else {
       Either::A((quality * 100.0) as u32)
     };
-    AsyncTask::new(AsyncBlob {
-      surface_ref: self.ctx.context.surface.reference(),
+    Ok(AsyncTask::new(AsyncBlob {
+      image,
       mime,
       quality_or_config,
       width: self.ctx.context.width,
       height: self.ctx.context.height,
-    })
+    }))
   }
 
   #[napi]
@@ -481,15 +517,20 @@ impl<'c> CanvasElement<'c> {
       Either3::C(_) => DEFAULT_JPEG_QUALITY,
     };
     let ctx2d = &self.ctx.context;
-    let surface_ref = ctx2d.surface.reference();
+    let image = ctx2d.surface.make_image_snapshot().ok_or_else(|| {
+      Error::new(
+        Status::GenericFailure,
+        "Create image snapshot failed".to_owned(),
+      )
+    })?;
 
     let task = match format_str {
-      "webp" => ContextData::Webp(surface_ref, quality),
-      "jpeg" => ContextData::Jpeg(surface_ref, quality),
-      "png" => ContextData::Png(surface_ref),
+      "webp" => ContextData::Webp(image, quality),
+      "jpeg" => ContextData::Jpeg(image, quality),
+      "png" => ContextData::Png(image),
       "avif" => {
         let cfg = AvifConfig::from(&quality_or_config);
-        ContextData::Avif(surface_ref, cfg.into(), ctx2d.width, ctx2d.height)
+        ContextData::Avif(image, cfg.into(), ctx2d.width, ctx2d.height)
       }
       "gif" => {
         let cfg = gif::GifConfig {
@@ -498,7 +539,7 @@ impl<'c> CanvasElement<'c> {
             _ => None,
           },
         };
-        ContextData::Gif(surface_ref, cfg, ctx2d.width, ctx2d.height)
+        ContextData::Gif(image, cfg, ctx2d.width, ctx2d.height)
       }
       _ => {
         return Err(Error::new(
@@ -517,8 +558,19 @@ impl<'c> CanvasElement<'c> {
     quality_or_config: Either3<f64, AvifConfig, Unknown>,
   ) -> Result<AsyncDataUrl> {
     let mime = mime.unwrap_or(MIME_PNG);
+    let image = self
+      .ctx
+      .context
+      .surface
+      .make_image_snapshot()
+      .ok_or_else(|| {
+        Error::new(
+          Status::GenericFailure,
+          "Create image snapshot failed".to_owned(),
+        )
+      })?;
     Ok(AsyncDataUrl {
-      surface_data: self.ctx.context.surface.reference(),
+      image,
       mime: mime.to_owned(),
       quality_or_config: match quality_or_config {
         Either3::A(q) => Either::A((q * 100.0) as u32),
@@ -537,7 +589,7 @@ pub struct ContextAttr {
 }
 
 fn get_data_ref(
-  surface_ref: &SurfaceRef,
+  image: &SkImage,
   mime: &str,
   quality_or_config: &Either<u32, AvifConfig>,
   width: u32,
@@ -546,24 +598,21 @@ fn get_data_ref(
   let quality = quality_or_config.to_quality(mime);
 
   if let Some(data_ref) = match mime {
-    MIME_WEBP => surface_ref.encode_data(sk::SkEncodedImageFormat::Webp, quality),
-    MIME_JPEG => surface_ref.encode_data(sk::SkEncodedImageFormat::Jpeg, quality),
-    MIME_PNG => surface_ref.png_data(),
+    MIME_WEBP => image.encode_data(sk::SkEncodedImageFormat::Webp, quality),
+    MIME_JPEG => image.encode_data(sk::SkEncodedImageFormat::Jpeg, quality),
+    MIME_PNG => image.encode_data(sk::SkEncodedImageFormat::Png, 100),
     MIME_AVIF => {
-      let (data, size) = surface_ref.data().ok_or_else(|| {
-        Error::new(
-          Status::GenericFailure,
-          "Encode to avif error, failed to get surface pixels".to_owned(),
-        )
-      })?;
+      let pixels = image
+        .read_pixels(AlphaType::Unpremultiplied)
+        .ok_or_else(|| {
+          Error::new(
+            Status::GenericFailure,
+            "Encode to avif error, failed to get surface pixels".to_owned(),
+          )
+        })?;
       let config = AvifConfig::from(quality_or_config).into();
-      let output = avif::encode(
-        unsafe { slice::from_raw_parts(data, size) },
-        width,
-        height,
-        &config,
-      )
-      .map_err(|e| Error::new(Status::GenericFailure, format!("{e}")))?;
+      let output = avif::encode(&pixels, width, height, &config)
+        .map_err(|e| Error::new(Status::GenericFailure, format!("{e}")))?;
       return Ok(ContextOutputData::Avif(output));
     }
     MIME_GIF => {
@@ -573,7 +622,15 @@ fn get_data_ref(
           _ => None,
         },
       };
-      let output = gif::encode_surface(surface_ref, width, height, &config)
+      let pixels = image
+        .read_pixels(AlphaType::Unpremultiplied)
+        .ok_or_else(|| {
+          Error::new(
+            Status::GenericFailure,
+            "Encode to gif error, failed to get surface pixels".to_owned(),
+          )
+        })?;
+      let output = gif::encode(&pixels, width, height, &config)
         .map_err(|e| Error::new(Status::GenericFailure, format!("{e}")))?;
       return Ok(ContextOutputData::Gif(output));
     }
@@ -594,7 +651,7 @@ fn get_data_ref(
 }
 
 pub struct AsyncDataUrl {
-  surface_data: SurfaceRef,
+  image: SkImage,
   quality_or_config: Either<u32, AvifConfig>,
   mime: String,
   width: u32,
@@ -609,7 +666,7 @@ impl Task for AsyncDataUrl {
   fn compute(&mut self) -> Result<Self::Output> {
     let mut output = format!("data:{};base64,", self.mime);
     let surface_data = get_data_ref(
-      &self.surface_data,
+      &self.image,
       &self.mime,
       &self.quality_or_config,
       self.width,
@@ -635,7 +692,7 @@ impl Task for AsyncDataUrl {
 }
 
 pub struct AsyncBlob {
-  surface_ref: SurfaceRef,
+  image: SkImage,
   mime: String,
   quality_or_config: Either<u32, AvifConfig>,
   width: u32,
@@ -649,7 +706,7 @@ impl<'env> ScopedTask<'env> for AsyncBlob {
 
   fn compute(&mut self) -> Result<Self::Output> {
     get_data_ref(
-      &self.surface_ref,
+      &self.image,
       &self.mime,
       &self.quality_or_config,
       self.width,

--- a/src/sk.rs
+++ b/src/sk.rs
@@ -1015,6 +1015,20 @@ pub mod ffi {
 
     pub fn skiac_image_get_height(image: *mut skiac_image) -> i32;
 
+    pub fn skiac_image_encode_data(
+      image: *mut skiac_image,
+      data: *mut skiac_sk_data,
+      format: i32,
+      quality: i32,
+    );
+
+    pub fn skiac_image_read_pixels(
+      image: *mut skiac_image,
+      dst: *mut u8,
+      row_bytes: usize,
+      alpha_type: i32,
+    ) -> bool;
+
     pub fn skiac_canvas_draw_sk_image(
       canvas: *mut skiac_canvas,
       image: *mut skiac_image,
@@ -4818,6 +4832,44 @@ impl SkImage {
     unsafe {
       ffi::skiac_canvas_draw_sk_image(canvas.0, self.0, left, top, filter_quality as i32);
     }
+  }
+
+  /// Encode the image into the given format (JPEG/PNG/WebP; quality is ignored for PNG)
+  pub fn encode_data(&self, format: SkEncodedImageFormat, quality: u8) -> Option<SkiaDataRef> {
+    unsafe {
+      let mut data = ffi::skiac_sk_data {
+        ptr: ptr::null_mut(),
+        size: 0,
+        data: ptr::null_mut(),
+      };
+      ffi::skiac_image_encode_data(self.0, &mut data, format as i32, quality as i32);
+
+      if data.ptr.is_null() {
+        None
+      } else {
+        Some(SkiaDataRef(data))
+      }
+    }
+  }
+
+  /// Read the whole image as RGBA_8888 pixels in the image's color space.
+  /// `alpha_type` must be [`AlphaType::Premultiplied`] or [`AlphaType::Unpremultiplied`];
+  /// Skia converts from the image's premultiplied storage when unpremultiplied is requested.
+  pub fn read_pixels(&self, alpha_type: AlphaType) -> Option<Vec<u8>> {
+    let sk_alpha_type = match alpha_type {
+      AlphaType::Premultiplied => 2,   // kPremul_SkAlphaType
+      AlphaType::Unpremultiplied => 3, // kUnpremul_SkAlphaType
+      _ => return None,
+    };
+    let width = self.width() as usize;
+    let height = self.height() as usize;
+    let row_bytes = width.checked_mul(4)?;
+    let size = row_bytes.checked_mul(height)?;
+    let mut pixels = vec![0u8; size];
+    let ok = unsafe {
+      ffi::skiac_image_read_pixels(self.0, pixels.as_mut_ptr(), row_bytes, sk_alpha_type)
+    };
+    if ok { Some(pixels) } else { None }
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #1313.

The async encode paths (`encode()`, `toDataURLAsync()`, `toBlob()`, `convertToBlob()`) captured a `SurfaceRef` — a pointer to the **live, mutable surface** — and encoded it later on the threadpool. PNG/JPEG/WebP called `makeImageSnapshot()` at compute time on the worker, and AVIF/GIF read the live backing buffer via `peekPixels().writable_addr()`. Drawing after the call (e.g. `clearRect`, which writes the surface directly, bypassing the deferred PageRecorder) leaked into the encoded output.

All encode entry points now capture an immutable `SkImage` snapshot on the JS thread immediately after `flush()`, and the worker encodes that snapshot — matching browser call-time capture semantics for `toBlob`/`toDataURL`. Raster snapshots share pixel memory copy-on-write, so the common encode-then-stop case stays cheap; a deep copy only happens if drawing continues, which is exactly when the semantics require it.

## Changes

- **New C shims**: `skiac_image_encode_data` (JPEG/PNG/WebP straight from an `SkImage`, same encoder options as the old surface path) and `skiac_image_read_pixels` (owned pixel copy, premul or unpremul).
- **`ContextData` / `AsyncDataUrl` / `AsyncBlob`** hold `SkImage` instead of `SurfaceRef`; `encode_inner`, `to_data_url_inner`, `to_blob`, `convert_to_blob`, `to_buffer` snapshot at call time. AVIF/GIF no longer pass a borrowed `writable_addr()` pointer to the worker (that was also a data race).
- **`Canvas.data()` returns an owned copy.** It previously exposed the surface's `writable_addr()` as a writable Buffer; writing through it bypasses Skia's copy-on-write and corrupted snapshots already captured by a queued encode (verified deterministically: `encode('png')` + `canvas.data().fill(0)` produced a cleared PNG). No in-repo consumer relies on writability.
- **AVIF/GIF receive straight (unpremultiplied) alpha** (pre-existing bug, found in review): libavif's `RgbPixels` declares its input `alphaPremultiplied=false` and gif's `Frame::from_rgba_speed` treats bytes as straight RGBA, so translucent colors were baked in darkened (e.g. `rgba(20,200,100,0.25)` → opaque `[5,49,25]` in GIF; AVIF files non-conformant, rendering dark in spec-conformant decoders). AVIF decode now also tags libavif's straight-alpha output as unpremultiplied — the decode-side tag previously cancelled out the encode-side bug for in-library round-trips only.

## Test plan

New `__test__/issue-1313-encode-snapshot.spec.ts` (13 tests), using the issue's deterministic threadpool-blocked repro:

- [x] `encode` png/jpeg/webp/gif/avif, `toDataURLAsync`, `toBlob`, `convertToBlob`: output byte-identical to a pre-mutation reference encode despite `clearRect` after the call
- [x] draws made after `encode()` are excluded
- [x] `canvas.data()` mutation after `encode()` does not leak into output; `data()` still returns correct pixel bytes
- [x] translucent GIF decodes to the straight color; translucent AVIF round-trips
- [x] AVIF conformance verified with an independent decoder (macOS ImageIO): `[20,195,100,64]` ≈ expected `[20,200,100,64]`
- [x] Full suite: 624 passed, 1 known pre-existing failure (`test.failing` W3C decode test), 13 skipped

Note: AVIF files written by previous releases were non-conformant (premultiplied bytes tagged as straight alpha); they now decode slightly differently, while conformant files from standard tooling now decode correctly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core encode/export and `canvas.data()` semantics (breaking for code that mutated the old zero-copy buffer); AVIF output from older releases may decode slightly differently after the alpha fix.
> 
> **Overview**
> Fixes **#1313** by making async export paths snapshot the canvas at **call time** instead of encoding the live surface later on the thread pool.
> 
> **`encode()`**, **`toDataURLAsync()`**, **`toBlob()`**, **`convertToBlob()`**, and related sync paths now **`flush()`**, then **`make_image_snapshot()`** on the JS thread and pass an immutable **`SkImage`** to workers. New Skia C APIs **`skiac_image_encode_data`** and **`skiac_image_read_pixels`** encode/read from that snapshot; AVIF/GIF use **unpremultiplied** pixel copies instead of borrowing the mutable surface buffer.
> 
> **`canvas.data()`** now returns an **owned pixel copy** (no writable view of the surface), so JS mutations cannot corrupt in-flight encodes. AVIF decode tags libavif output as **unpremultiplied**; GIF/AVIF encode fixes translucent color handling.
> 
> Adds **`__test__/issue-1313-encode-snapshot.spec.ts`** with threadpool-blocking tests for all formats and blob/dataURL APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4a1774d5f882bb3190ffbfb1ac0f830d6948d91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->