### PR TITLE
fix: snapshot canvas source in drawImage to avoid per-call pixel copy

### DIFF
--- a/__test__/issue-1321-drawimage-snapshot.spec.ts
+++ b/__test__/issue-1321-drawimage-snapshot.spec.ts
@@ -61,19 +61,25 @@ test('drawImage(canvas) self-blit uses call-time pixels', (t) => {
   const actx = canvas.getContext('2d')
   actx.fillStyle = '#ff0000'
   actx.fillRect(0, 0, 256, 256)
+  actx.fillStyle = '#00ff00'
+  actx.fillRect(0, 0, 32, 32)
 
-  actx.drawImage(canvas, 16, 16)
+  // The green marker square lands at (128, 128); the pixel there was red
+  // before the blit, so a dropped blit fails the first assertion.
+  actx.drawImage(canvas, 128, 128)
 
+  // Overwrite the original marker after the blit: the copy must keep the
+  // call-time green, not the later blue.
   actx.fillStyle = '#0000ff'
-  actx.fillRect(0, 0, 1, 1)
+  actx.fillRect(0, 0, 32, 32)
 
   t.deepEqual(
-    Array.from(actx.getImageData(200, 200, 1, 1).data),
-    [255, 0, 0, 255],
-    'self-blit must copy the red pixels captured at call time',
+    Array.from(actx.getImageData(140, 140, 1, 1).data),
+    [0, 255, 0, 255],
+    'self-blit must copy the green marker captured at call time',
   )
   t.deepEqual(
-    Array.from(actx.getImageData(0, 0, 1, 1).data),
+    Array.from(actx.getImageData(10, 10, 1, 1).data),
     [0, 0, 255, 255],
     'drawing after the self-blit must still land on the surface',
   )

--- a/__test__/issue-1321-drawimage-snapshot.spec.ts
+++ b/__test__/issue-1321-drawimage-snapshot.spec.ts
@@ -1,0 +1,103 @@
+import test from 'ava'
+
+import { createCanvas } from '../index.js'
+
+// https://github.com/Brooooooklyn/canvas/issues/1321
+// Canvas→canvas drawImage must take a zero-copy snapshot of the source surface
+// at call time: later writes into the source trigger Skia copy-on-write instead
+// of leaking into the destination, and repeated unflushed blits must not each
+// pin their own copy of the source pixel buffer.
+
+test('drawImage(canvas) captures call-time pixels when source is later modified', (t) => {
+  const src = createCanvas(256, 256)
+  const sctx = src.getContext('2d')
+  sctx.fillStyle = '#ff0000'
+  sctx.fillRect(0, 0, 256, 256)
+
+  const dst = createCanvas(256, 256)
+  const dctx = dst.getContext('2d')
+  dctx.drawImage(src, 0, 0)
+
+  // Repaint the source green and force its surface write before reading the
+  // destination, so the recorded blit must rely on copy-on-write.
+  sctx.fillStyle = '#00ff00'
+  sctx.fillRect(0, 0, 256, 256)
+  src.toBuffer('image/png')
+
+  t.deepEqual(
+    Array.from(dctx.getImageData(128, 128, 1, 1).data),
+    [255, 0, 0, 255],
+    'destination must keep the red pixels captured when drawImage was called',
+  )
+})
+
+test('drawImage(canvas) captures call-time pixels when source was encoded before the blit', (t) => {
+  const src = createCanvas(256, 256)
+  const sctx = src.getContext('2d')
+  sctx.fillStyle = '#ff0000'
+  sctx.fillRect(0, 0, 256, 256)
+
+  // Encoding snapshots the source surface; the blit below must still hold its
+  // own reference so a later source write cannot restore mutability in place.
+  src.toBuffer('image/png')
+
+  const dst = createCanvas(256, 256)
+  const dctx = dst.getContext('2d')
+  dctx.drawImage(src, 0, 0)
+
+  sctx.fillStyle = '#00ff00'
+  sctx.fillRect(0, 0, 256, 256)
+  src.toBuffer('image/png')
+
+  t.deepEqual(
+    Array.from(dctx.getImageData(128, 128, 1, 1).data),
+    [255, 0, 0, 255],
+    'destination must not show the green fill drawn after the blit',
+  )
+})
+
+test('drawImage(canvas) self-blit uses call-time pixels', (t) => {
+  const canvas = createCanvas(256, 256)
+  const actx = canvas.getContext('2d')
+  actx.fillStyle = '#ff0000'
+  actx.fillRect(0, 0, 256, 256)
+
+  actx.drawImage(canvas, 16, 16)
+
+  actx.fillStyle = '#0000ff'
+  actx.fillRect(0, 0, 1, 1)
+
+  t.deepEqual(
+    Array.from(actx.getImageData(200, 200, 1, 1).data),
+    [255, 0, 0, 255],
+    'self-blit must copy the red pixels captured at call time',
+  )
+  t.deepEqual(
+    Array.from(actx.getImageData(0, 0, 1, 1).data),
+    [0, 0, 255, 255],
+    'drawing after the self-blit must still land on the surface',
+  )
+})
+
+test('drawImage(canvas) does not pin one buffer copy per blit', (t) => {
+  const src = createCanvas(1920, 1080)
+  const sctx = src.getContext('2d')
+  sctx.fillStyle = '#ff0000'
+  sctx.fillRect(0, 0, 1920, 1080)
+
+  const dst = createCanvas(1920, 1080)
+  const dctx = dst.getContext('2d')
+
+  const before = process.memoryUsage.rss()
+  for (let i = 0; i < 100; i++) {
+    dctx.drawImage(src, 0, 0)
+  }
+  const delta = process.memoryUsage.rss() - before
+
+  // Each eager copy of a 1080p surface is ~8.3 MB; 100 unflushed blits used to
+  // pin ~800 MB. Snapshots share the pixels, so growth stays far below 100 MB.
+  t.true(
+    delta < 100 * 1024 * 1024,
+    `100 unflushed blits grew rss by ${(delta / 1024 / 1024).toFixed(1)} MB, expected < 100 MB`,
+  )
+})

--- a/skia-c/skia_c.cpp
+++ b/skia-c/skia_c.cpp
@@ -437,16 +437,24 @@ void skiac_canvas_draw_image(skiac_canvas* c_canvas,
   auto paint = reinterpret_cast<const SkPaint*>(c_paint);
   if (is_canvas) {
     auto src_surface = reinterpret_cast<SkSurface*>(c_bitmap);
+    // Snapshot instead of SkSurface::draw -- on a never-snapshotted surface
+    // SkSurface::draw copies the whole pixel buffer on every call (#1321).
+    // The snapshot shares the pixels; a later write into the source
+    // copies-on-write, which keeps call-time capture semantics.
+    sk_sp<SkImage> snapshot = src_surface->makeImageSnapshot();
+    if (!snapshot) {
+      return;
+    }
     CANVAS_CAST->save();
     // Translate to the destination position
     CANVAS_CAST->translate(dx, dy);
-    // The source crop -- SkSurface::draw paints the whole source surface. It
+    // The source crop -- drawImage paints the whole source snapshot. It
     // would truncate a halo, so `paint` must carry no image filter.
     CANVAS_CAST->clipRect(SkRect::MakeWH(d_width, d_height));
     // Scale using the ratio of destination size to source surface size
     CANVAS_CAST->scale(d_width / s_width, d_height / s_height);
-    // Draw the surface directly
-    src_surface->draw(CANVAS_CAST, -sx, -sy, sampling, paint);
+    // Draw the snapshot directly
+    CANVAS_CAST->drawImage(snapshot.get(), -sx, -sy, sampling, paint);
     CANVAS_CAST->restore();
   } else {
     const auto src_rect = SkRect::MakeXYWH(sx, sy, s_width, s_height);


### PR DESCRIPTION
Closes #1321. This is the open remainder of #1318 (the `getImageData` half was fixed in 1.0.7).

## Root cause

Canvas→canvas `drawImage` went through `SkSurface::draw`, which calls `fBitmap.asImage()`. On a source surface whose pixelRef is still **mutable** — one that has never been snapshotted — `asImage()` eagerly copies the whole pixel buffer, on **every call**, inside the `drawImage` call itself:

```
drawImage(srcCanvas, ...)                       is_canvas branch, skia_c.cpp
  └─ src_surface->draw(...)                     SkSurface::draw
       └─ SkSurface_Raster::onDraw
            └─ canvas->drawImage(fBitmap.asImage(), ...)
                 └─ MakeFromBitmap(bm, kIfMutable)
                      ├─ pixels MUTABLE   → SkData::MakeWithCopy  ← 8.3 MB @1080p, EVERY call
                      └─ pixels IMMUTABLE → share pixels          ← ~1 µs
```

The only thing that flipped a source into the cheap immutable state was the consolidation snapshot in `Context::flush`, gated on `layers.len() > 1`. A scratch canvas painted **exactly once** never crosses that gate, so it paid the copy forever — precisely the "painted once, never re-drawn" state #1321 isolates. Each recorded blit also pinned its own copy: 100 unflushed blits of a 1080p source held ~800 MB.

## The fix

Take a no-arg `makeImageSnapshot()` of the source and draw that image, inside the unchanged save/translate/clipRect/scale wrapper (so rendering is identical — `SkSurface_Raster::onDraw` is literally `drawImage(asImage(), ...)`). The no-arg snapshot is zero-copy on raster surfaces: Skia caches it on the surface and marks the pixels temporarily immutable. All blits share one image; a later write into the source triggers Skia's copy-on-write, which preserves call-time capture semantics.

## Second bug this fixes (call-time capture violation in 1.0.7)

If the source was snapshotted by something else first (e.g. `toBuffer()`, since #1323) and then blitted, the old path shared the pixelRef **without** holding a snapshot reference. A later repaint of the source then took Skia's `restoreMutability` in-place branch, and the destination showed pixels drawn **after** the blit:

```js
src red → src.toBuffer() → dst.drawImage(src) → src green → src.toBuffer()
dst.getImageData(...)  // 1.0.7: green (wrong) — this PR: red (correct)
```

`__test__/issue-1321-drawimage-snapshot.spec.ts` covers both bugs; on the unfixed build the capture test and the memory test fail (verified), on this branch all 628 tests pass.

## Numbers (darwin-arm64, release builds, 1920×1080, source painted once)

| metric | 1.0.7 | this PR |
|---|---:|---:|
| `drawImage` call, median | 0.484 ms | **0.0024 ms** |
| realized cost per blit (k blits + flush, slope k=1→8) | 0.924 ms | **0.438 ms** (2.1×) |
| RSS growth, 100 unflushed blits | 801.7 MB | **8.0 MB** |

The remaining 0.44 ms is plain rasterization — it now matches the `Image`-source path, which was the reporter's own baseline for "unremarkable". On the reporter's Windows box this should take the 4.06 ms/blit arm down to ~2.3 ms, in line with their `Image`-source measurement (2.28 ms).

Trade-off: the first write into a source after a blit pays one copy-on-write copy of the surface. That is one copy per repaint-after-blit instead of one copy per blit — never more than before, and strictly less whenever a source is blitted more than once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UnWoreneSBpQj9Rn4zH5im

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the native canvas blit path, so incorrect snapshot/COW behavior could leak later source pixels into destinations or change memory use. Scope is a small, well-tested change in one draw branch.
> 
> **Overview**
> Canvas→canvas `drawImage` now snapshots the source with `makeImageSnapshot()` and draws that image, instead of `SkSurface::draw`.
> 
> That stops Skia from eagerly copying the whole pixel buffer on every blit of a never-snapshotted surface (#1321), so repeated unflushed blits share one buffer. Holding the snapshot also keeps call-time pixels when the source is later rewritten (including after `toBuffer()`), via copy-on-write rather than in-place mutability restore.
> 
> Tests cover later source mutation, encode-then-blit capture, self-blit, and RSS growth for 100 unflushed 1080p blits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efb391a894ac542a52660c172fbac64c8981017a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->