### PR TITLE
ci: repair armv7 apt sources and musl builder image

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -228,6 +228,16 @@ jobs:
     steps:
       - name: Setup tools
         run: |
+            # Debian 11 LTS ended on 2026-08-31. The bullseye-security index is frozen
+            # (Valid-Until 2026-09-07) and its pool is now only partially mirrored:
+            # deb.debian.org and security.debian.org each return 404 for files the
+            # other still serves, and both have dropped llvm-toolchain-19. Add both
+            # mirrors plus a dated snapshot so apt can fall back, and accept the
+            # frozen index on those entries only. Live repositories added below
+            # (apt.llvm.org, nodesource) keep their expiry check.
+            sed -i 's|^deb http://deb.debian.org/debian-security|deb [check-valid-until=no] http://deb.debian.org/debian-security|' /etc/apt/sources.list
+            echo "deb [check-valid-until=no] http://security.debian.org/debian-security bullseye-security main" >> /etc/apt/sources.list
+            echo "deb [check-valid-until=no] http://snapshot.debian.org/archive/debian-security/20260824T000000Z bullseye-security main" >> /etc/apt/sources.list
             apt-get update
             apt-get install -y gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf libatomic1-armhf-cross git build-essential cmake ninja-build wget curl gnupg
             echo "deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-19 main" >> /etc/apt/sources.list

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -238,6 +238,11 @@ jobs:
             sed -i 's|^deb http://deb.debian.org/debian-security|deb [check-valid-until=no] http://deb.debian.org/debian-security|' /etc/apt/sources.list
             echo "deb [check-valid-until=no] http://security.debian.org/debian-security bullseye-security main" >> /etc/apt/sources.list
             echo "deb [check-valid-until=no] http://snapshot.debian.org/archive/debian-security/20260824T000000Z bullseye-security main" >> /etc/apt/sources.list
+            # llvm-toolchain-19 is on the snapshot only, so that source has no
+            # alternate. apt 2.2 retries zero times by default, which turns a
+            # rate-limit or timeout into a failed build. Retry transient errors.
+            # A 404 stays a permanent error, so mirror fallback is still immediate.
+            echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80retries
             apt-get update
             apt-get install -y gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf libatomic1-armhf-cross git build-essential cmake ninja-build wget curl gnupg
             echo "deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-19 main" >> /etc/apt/sources.list

--- a/.github/workflows/skia.yaml
+++ b/.github/workflows/skia.yaml
@@ -352,6 +352,10 @@ jobs:
           sed -i 's|^deb http://deb.debian.org/debian-security|deb [check-valid-until=no] http://deb.debian.org/debian-security|' /etc/apt/sources.list
           echo "deb [check-valid-until=no] http://security.debian.org/debian-security bullseye-security main" >> /etc/apt/sources.list
           echo "deb [check-valid-until=no] http://snapshot.debian.org/archive/debian-security/20260824T000000Z bullseye-security main" >> /etc/apt/sources.list
+          # apt 2.2 retries zero times by default, which turns a rate-limit or
+          # timeout on any mirror into a failed build. Retry transient errors.
+          # A 404 stays a permanent error, so mirror fallback is still immediate.
+          echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80retries
           apt-get update
           apt-get install -y gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf libatomic1-armhf-cross git build-essential cmake ninja-build wget curl python3
           curl -fsSL https://deb.nodesource.com/setup_22.x | bash -

--- a/.github/workflows/skia.yaml
+++ b/.github/workflows/skia.yaml
@@ -343,6 +343,15 @@ jobs:
     steps:
       - name: Setup tools
         run: |
+          # Debian 11 LTS ended on 2026-08-31. The bullseye-security index is frozen
+          # (Valid-Until 2026-09-07) and its pool is now only partially mirrored:
+          # deb.debian.org and security.debian.org each return 404 for files the
+          # other still serves. Add both mirrors plus a dated snapshot so apt can
+          # fall back, and accept the frozen index on those entries only. Live
+          # repositories added below (nodesource) keep their expiry check.
+          sed -i 's|^deb http://deb.debian.org/debian-security|deb [check-valid-until=no] http://deb.debian.org/debian-security|' /etc/apt/sources.list
+          echo "deb [check-valid-until=no] http://security.debian.org/debian-security bullseye-security main" >> /etc/apt/sources.list
+          echo "deb [check-valid-until=no] http://snapshot.debian.org/archive/debian-security/20260824T000000Z bullseye-security main" >> /etc/apt/sources.list
           apt-get update
           apt-get install -y gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf libatomic1-armhf-cross git build-essential cmake ninja-build wget curl python3
           curl -fsSL https://deb.nodesource.com/setup_22.x | bash -

--- a/musl.Dockerfile
+++ b/musl.Dockerfile
@@ -21,7 +21,6 @@ RUN apk add --no-cache \
   tar \
   xz \
   ninja && \
-  gn && \
   apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing gn perl nasm aom-dev meson && \
   ln -sf /usr/bin/python3 /usr/bin/python
 


### PR DESCRIPTION
## Why

Three CI failures on `main`. All of them sit in container setup steps, not in project code.

| Failure | Workflow | Kind |
|---|---|---|
| `apt-get` exit 100, 404 on `bullseye-security` files | `CI.yaml`, `skia.yaml` armv7 | infrastructure, gets worse on 2026-09-07 |
| `/bin/sh: gn: not found`, exit 127 | `musl.Dockerfile` | code defect, present since 2025-08-28 |
| `Could not resolve 'apt.llvm.org'` | `Dockerfile` (nightly) | transient, no code change |

## armv7 jobs — Debian 11 mirror rot

Debian 11 LTS ended on 2026-08-31. The `bullseye-security` suite is frozen and its pool is now only partly mirrored. The index still lists every file, but the mirrors no longer serve them all, and each mirror is missing a **different** subset:

| file | `deb.debian.org` | `security.debian.org` | snapshot `20260824` |
|---|---|---|---|
| `gnupg-l10n` deb11u3 | 404 | 200 | 200 |
| `gnupg` deb11u3 | 200 | 404 | 200 |
| `llvm-19-dev` deb11u1 | 404 | 404 | 200 |
| `libclang-cpp19` deb11u1 | 404 | 404 | 200 |

So no single mirror completes the install. The fix lists all three, and apt falls back per file:

```
gnupg-l10n, gpgsm   deb.debian.org Ign → security.debian.org Get
libclang-cpp19      deb.debian.org Ign → security.debian.org Ign → snapshot Get
llvm-19-dev         deb.debian.org Ign → security.debian.org Ign → snapshot Get
```

Two further points:

1. **The snapshot date matters.** `20260906T000000Z` already 404s; `20260824T000000Z` still serves every file. That date is the one the `debian:11` image itself ships, commented out, in `/etc/apt/sources.list`.
2. **The frozen index expires on 2026-09-07.** After that `apt-get update` fails on expiry alone. The security entries therefore take `check-valid-until=no`. The option is scoped to those entries only, so `apt.llvm.org` and nodesource — added later in the same step — keep their expiry check.

## musl builder image

A stray `gn` shell token sat between the two `apk add` commands:

```dockerfile
  ninja && \
  gn && \                                    # ← removed
  apk add --repository edge/testing gn ...   # ← gn arrives here
```

The `gn` package is not in alpine `main` or `community`. It comes from `edge/testing`, in the *next* `apk add`. So the shell ran `gn` before it existed and the layer always failed with exit 127.

Commit ec4152c (2025-08-28) introduced the line. The Docker nightly build has failed in every run since — the last 200 scheduled runs all failed.

## Verification

Each change was run in a real container, not reasoned about.

| Check | Command | Result |
|---|---|---|
| `CI.yaml` armv7 setup step | full step in `debian:11` | exit 0, `Debian clang version 19.1.7` |
| `skia.yaml` armv7 setup step | full step in `debian:11` | exit 0 |
| musl image | `docker build -f musl.Dockerfile` | exit 0 |

Both setup steps were extracted from the workflow files themselves, so the verified script is the shipped script.

## Retry hardening

`llvm-19-dev` and `libclang-cpp19` come from the snapshot alone, so that one source has no alternate. apt 2.2 in bullseye sets no `Acquire::Retries` default, which means zero. One rate-limit or timeout from `snapshot.debian.org` would abort the setup step.

`Acquire::Retries` is now 3. A 404 stays a permanent error in apt, so mirror fallback is still immediate — the verification log shows a single `Ign` per mirror before the snapshot serves the file.

## Review

Two rounds of `/codex:adversarial-review`.

| Round | Verdict | Suggestion | Action |
|---|---|---|---|
| 1 | approve | scope the expiry override per source | applied |
| 1 | approve | pin a dated snapshot | applied |
| 2 | needs-attention | apt retries zero times by default | verified, applied |
| 2 | needs-attention | pin `clang-19` to apt.llvm.org instead | not applied, see below |

**Handed back, not decided here.** Round 2 proposed dropping the Debian `clang-19` (`1:19.1.7-3~deb11u1`) in favour of the apt.llvm.org build via package preferences. That swaps the compiler which produces the shipped armv7 binary. It is a toolchain decision, not a CI repair, so it does not belong in this PR.

## Not fixed

The 2026-09-06 nightly also hit a DNS failure resolving `apt.llvm.org`. That is transient and clears on a re-run. No code change applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014jTPz7qQMBuVM334rs2FaS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI workflow setup scripts and a Docker build image; no runtime, auth, or product code paths are touched.
> 
> **Overview**
> Repairs **CI container bootstrap** failures after Debian 11 LTS ended, without changing application build logic.
> 
> For **armv7** jobs in `CI.yaml` and `skia.yaml` (both use `debian:11`), the **Setup tools** step now rewrites `bullseye-security` apt sources: multiple mirrors plus a pinned `snapshot.debian.org` archive, `check-valid-until=no` only on those frozen security entries, and `Acquire::Retries "3"` so transient mirror errors can fall back per package. The CI armv7 job still adds LLVM 19 and Node afterward; live repos keep normal expiry checks.
> 
> In **`musl.Dockerfile`**, a stray **`gn &&`** between two `apk add` lines is removed so the image no longer tries to execute `gn` before it is installed from Alpine `edge/testing`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c01622415e5619d67ddcaef4a7ad64ca1f314f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
