### PR TITLE
fix: invalidate FontCollection typeface cache on font registration

### DIFF
--- a/__test__/issue-1329-font-cache.spec.ts
+++ b/__test__/issue-1329-font-cache.spec.ts
@@ -1,0 +1,98 @@
+import { readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import test from 'ava'
+
+import { createCanvas, GlobalFonts } from '../index'
+
+// https://github.com/Brooooooklyn/canvas/issues/1329
+// skparagraph's FontCollection memoizes findTypefaces() per
+// {family list, weight, slant}. Registering a face never invalidated that
+// cache, so any family/weight resolved before its face existed stayed pinned
+// to the older match for the rest of the process.
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const regularData = readFileSync(join(__dirname, 'fonts', 'SourceSerifPro-Regular.ttf'))
+const boldData = readFileSync(join(__dirname, 'fonts', 'SourceHanSerifCN-Bold.ttf'))
+
+const SAMPLE = 'Andilly (95)'
+
+function measure(font: string) {
+  const ctx = createCanvas(10, 10).getContext('2d')
+  ctx.font = font
+  return ctx.measureText(SAMPLE).width
+}
+
+test.serial('registering a family invalidates a lookup cached before it existed', (t) => {
+  const family = 'Issue1329Late'
+
+  // Poison the cache: the family has no face yet, so this resolves to the
+  // fallback and the miss is memoized under {[family], 400, upright}.
+  const stale = measure(`400 60px "${family}"`)
+
+  GlobalFonts.register(regularData, family)
+
+  // A family list the cache has never seen resolves the registered face.
+  // It is the ground truth for what the poisoned key must now return.
+  const expected = measure(`400 60px "${family}", serif`)
+
+  t.not(stale, expected, 'fallback and registered face must differ, otherwise the test proves nothing')
+  t.is(measure(`400 60px "${family}"`), expected)
+})
+
+test.serial('registering a second weight invalidates the cached first weight', (t) => {
+  const family = 'Issue1329Weight'
+
+  GlobalFonts.register(boldData, family)
+
+  // Only the bold face exists, so weight 400 resolves to it and is memoized.
+  const stale = measure(`400 60px "${family}"`)
+  t.is(stale, measure(`700 60px "${family}"`), 'weight 400 must fall back to the only face')
+
+  GlobalFonts.register(regularData, family)
+
+  const expected = measure(`400 60px "${family}", serif`)
+  t.not(stale, expected, 'the two faces must have different metrics')
+  t.is(measure(`400 60px "${family}"`), expected)
+
+  // The bold face must survive the invalidation.
+  t.is(measure(`700 60px "${family}"`), stale)
+})
+
+test.serial('font size is not part of the cache key', (t) => {
+  const family = 'Issue1329Size'
+
+  GlobalFonts.register(boldData, family)
+  measure(`400 60px "${family}"`)
+  GlobalFonts.register(regularData, family)
+
+  t.is(measure(`400 30px "${family}"`), measure(`400 30px "${family}", serif`))
+})
+
+test.serial('setAlias invalidates a lookup cached before the alias existed', (t) => {
+  const family = 'Issue1329AliasTarget'
+  const alias = 'Issue1329Alias'
+
+  GlobalFonts.register(regularData, family)
+
+  const stale = measure(`400 60px "${alias}"`)
+
+  t.true(GlobalFonts.setAlias(family, alias))
+
+  const expected = measure(`400 60px "${alias}", serif`)
+  t.not(stale, expected, 'fallback and aliased face must differ, otherwise the test proves nothing')
+  t.is(measure(`400 60px "${alias}"`), expected)
+})
+
+test.serial('registerFromPath invalidates a lookup cached before it existed', (t) => {
+  const family = 'Issue1329Path'
+
+  const stale = measure(`400 60px "${family}"`)
+
+  GlobalFonts.registerFromPath(join(__dirname, 'fonts', 'SourceSerifPro-Regular.ttf'), family)
+
+  const expected = measure(`400 60px "${family}", serif`)
+  t.not(stale, expected, 'fallback and registered face must differ, otherwise the test proves nothing')
+  t.is(measure(`400 60px "${family}"`), expected)
+})

--- a/__test__/issue-1329-font-cache.spec.ts
+++ b/__test__/issue-1329-font-cache.spec.ts
@@ -13,8 +13,10 @@ import { createCanvas, GlobalFonts } from '../index'
 // to the older match for the rest of the process.
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
-const regularData = readFileSync(join(__dirname, 'fonts', 'SourceSerifPro-Regular.ttf'))
+const serifPath = join(__dirname, 'fonts', 'SourceSerifPro-Regular.ttf')
+const serifData = readFileSync(serifPath)
 const boldData = readFileSync(join(__dirname, 'fonts', 'SourceHanSerifCN-Bold.ttf'))
+const anchorData = readFileSync(join(__dirname, 'fonts', 'Oswald.ttf'))
 
 const SAMPLE = 'Andilly (95)'
 
@@ -24,21 +26,41 @@ function measure(font: string) {
   return ctx.measureText(SAMPLE).width
 }
 
+// A registered anchor family, appended to every family list that starts with a
+// family under test. Before the family under test has a face the list resolves
+// to the anchor; afterwards the first entry must win. CI images carry no system
+// fonts, so relying on the ambient fallback instead would not be deterministic.
+const ANCHOR = 'Issue1329Anchor'
+GlobalFonts.register(anchorData, ANCHOR)
+
+// Reference widths, each read through a family that is registered up front and
+// never mutated, so no cache entry under test can influence them.
+GlobalFonts.register(serifData, 'Issue1329SerifRef')
+GlobalFonts.register(boldData, 'Issue1329BoldRef')
+
+const ANCHOR_WIDTH = measure(`400 60px "${ANCHOR}"`)
+const SERIF_WIDTH = measure(`400 60px "Issue1329SerifRef"`)
+const SERIF_WIDTH_30 = measure(`400 30px "Issue1329SerifRef"`)
+const BOLD_WIDTH = measure(`700 60px "Issue1329BoldRef"`)
+const BOLD_WIDTH_30 = measure(`700 30px "Issue1329BoldRef"`)
+
+test.serial('the three reference faces have distinct metrics', (t) => {
+  // Guards every assertion below: equal widths would make them pass vacuously.
+  t.not(ANCHOR_WIDTH, SERIF_WIDTH)
+  t.not(BOLD_WIDTH, SERIF_WIDTH)
+  t.not(BOLD_WIDTH_30, SERIF_WIDTH_30)
+})
+
 test.serial('registering a family invalidates a lookup cached before it existed', (t) => {
   const family = 'Issue1329Late'
 
-  // Poison the cache: the family has no face yet, so this resolves to the
-  // fallback and the miss is memoized under {[family], 400, upright}.
-  const stale = measure(`400 60px "${family}"`)
+  // Poison the cache: the family has no face yet, so the list falls through to
+  // the anchor and that match is memoized under {[family, ANCHOR], 400, upright}.
+  t.is(measure(`400 60px "${family}", "${ANCHOR}"`), ANCHOR_WIDTH)
 
-  GlobalFonts.register(regularData, family)
+  GlobalFonts.register(serifData, family)
 
-  // A family list the cache has never seen resolves the registered face.
-  // It is the ground truth for what the poisoned key must now return.
-  const expected = measure(`400 60px "${family}", serif`)
-
-  t.not(stale, expected, 'fallback and registered face must differ, otherwise the test proves nothing')
-  t.is(measure(`400 60px "${family}"`), expected)
+  t.is(measure(`400 60px "${family}", "${ANCHOR}"`), SERIF_WIDTH)
 })
 
 test.serial('registering a second weight invalidates the cached first weight', (t) => {
@@ -47,52 +69,47 @@ test.serial('registering a second weight invalidates the cached first weight', (
   GlobalFonts.register(boldData, family)
 
   // Only the bold face exists, so weight 400 resolves to it and is memoized.
-  const stale = measure(`400 60px "${family}"`)
-  t.is(stale, measure(`700 60px "${family}"`), 'weight 400 must fall back to the only face')
+  t.is(measure(`400 60px "${family}"`), BOLD_WIDTH)
 
-  GlobalFonts.register(regularData, family)
+  GlobalFonts.register(serifData, family)
 
-  const expected = measure(`400 60px "${family}", serif`)
-  t.not(stale, expected, 'the two faces must have different metrics')
-  t.is(measure(`400 60px "${family}"`), expected)
-
+  t.is(measure(`400 60px "${family}"`), SERIF_WIDTH)
   // The bold face must survive the invalidation.
-  t.is(measure(`700 60px "${family}"`), stale)
+  t.is(measure(`700 60px "${family}"`), BOLD_WIDTH)
 })
 
 test.serial('font size is not part of the cache key', (t) => {
   const family = 'Issue1329Size'
 
   GlobalFonts.register(boldData, family)
-  measure(`400 60px "${family}"`)
-  GlobalFonts.register(regularData, family)
+  // Poison at 60px; 30px shares the key because size lives in SkFont, not in
+  // the SkFontStyle the key is built from.
+  t.is(measure(`400 60px "${family}"`), BOLD_WIDTH)
 
-  t.is(measure(`400 30px "${family}"`), measure(`400 30px "${family}", serif`))
+  GlobalFonts.register(serifData, family)
+
+  t.is(measure(`400 30px "${family}"`), SERIF_WIDTH_30)
 })
 
 test.serial('setAlias invalidates a lookup cached before the alias existed', (t) => {
   const family = 'Issue1329AliasTarget'
   const alias = 'Issue1329Alias'
 
-  GlobalFonts.register(regularData, family)
+  GlobalFonts.register(serifData, family)
 
-  const stale = measure(`400 60px "${alias}"`)
+  t.is(measure(`400 60px "${alias}", "${ANCHOR}"`), ANCHOR_WIDTH)
 
   t.true(GlobalFonts.setAlias(family, alias))
 
-  const expected = measure(`400 60px "${alias}", serif`)
-  t.not(stale, expected, 'fallback and aliased face must differ, otherwise the test proves nothing')
-  t.is(measure(`400 60px "${alias}"`), expected)
+  t.is(measure(`400 60px "${alias}", "${ANCHOR}"`), SERIF_WIDTH)
 })
 
 test.serial('registerFromPath invalidates a lookup cached before it existed', (t) => {
   const family = 'Issue1329Path'
 
-  const stale = measure(`400 60px "${family}"`)
+  t.is(measure(`400 60px "${family}", "${ANCHOR}"`), ANCHOR_WIDTH)
 
-  GlobalFonts.registerFromPath(join(__dirname, 'fonts', 'SourceSerifPro-Regular.ttf'), family)
+  GlobalFonts.registerFromPath(serifPath, family)
 
-  const expected = measure(`400 60px "${family}", serif`)
-  t.not(stale, expected, 'fallback and registered face must differ, otherwise the test proves nothing')
-  t.is(measure(`400 60px "${family}"`), expected)
+  t.is(measure(`400 60px "${family}", "${ANCHOR}"`), SERIF_WIDTH)
 })

--- a/__test__/issue-1329-font-cache.spec.ts
+++ b/__test__/issue-1329-font-cache.spec.ts
@@ -15,8 +15,11 @@ import { createCanvas, GlobalFonts } from '../index'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const serifPath = join(__dirname, 'fonts', 'SourceSerifPro-Regular.ttf')
 const serifData = readFileSync(serifPath)
-const boldData = readFileSync(join(__dirname, 'fonts', 'SourceHanSerifCN-Bold.ttf'))
 const anchorData = readFileSync(join(__dirname, 'fonts', 'Oswald.ttf'))
+// The only committed face that is neither weight 400 nor monospace, so the only
+// one whose advance width differs from the regular at a different weight.
+// Registered by path because it is 14.6 MB and the path API loads it lazily.
+const boldPath = join(__dirname, 'fonts', 'SourceHanSerifCN-Bold.ttf')
 
 const SAMPLE = 'Andilly (95)'
 
@@ -36,7 +39,7 @@ GlobalFonts.register(anchorData, ANCHOR)
 // Reference widths, each read through a family that is registered up front and
 // never mutated, so no cache entry under test can influence them.
 GlobalFonts.register(serifData, 'Issue1329SerifRef')
-GlobalFonts.register(boldData, 'Issue1329BoldRef')
+GlobalFonts.registerFromPath(boldPath, 'Issue1329BoldRef')
 
 const ANCHOR_WIDTH = measure(`400 60px "${ANCHOR}"`)
 const SERIF_WIDTH = measure(`400 60px "Issue1329SerifRef"`)
@@ -66,7 +69,7 @@ test.serial('registering a family invalidates a lookup cached before it existed'
 test.serial('registering a second weight invalidates the cached first weight', (t) => {
   const family = 'Issue1329Weight'
 
-  GlobalFonts.register(boldData, family)
+  GlobalFonts.registerFromPath(boldPath, family)
 
   // Only the bold face exists, so weight 400 resolves to it and is memoized.
   t.is(measure(`400 60px "${family}"`), BOLD_WIDTH)
@@ -81,7 +84,7 @@ test.serial('registering a second weight invalidates the cached first weight', (
 test.serial('font size is not part of the cache key', (t) => {
   const family = 'Issue1329Size'
 
-  GlobalFonts.register(boldData, family)
+  GlobalFonts.registerFromPath(boldPath, family)
   // Poison at 60px; 30px shares the key because size lives in SkFont, not in
   // the SkFontStyle the key is built from.
   t.is(measure(`400 60px "${family}"`), BOLD_WIDTH)

--- a/skia-c/skia_c.cpp
+++ b/skia-c/skia_c.cpp
@@ -542,6 +542,9 @@ void skiac_canvas_get_line_metrics_or_draw_text(
     int variant_caps,
     const char* lang,
     int text_rendering) {
+  // A face or alias registered since the last lookup can change an existing
+  // match, and FontCollection caches matches until told otherwise.
+  c_collection->flushCachesIfDirty();
   auto font_collection = c_collection->collection;
   auto font_style = SkFontStyle(weight, stretch, (SkFontStyle::Slant)slant);
   auto text_direction = (TextDirection)direction;
@@ -2303,6 +2306,9 @@ uint32_t skiac_font_collection_register(
     typeface_id = c_font_collection->assets->registerTypefaceWithTracking(
         typeface_data, typeface);
   }
+  if (typeface_id) {
+    c_font_collection->markCachesDirty();
+  }
   return typeface_id;
 }
 
@@ -2329,6 +2335,9 @@ uint32_t skiac_font_collection_register_from_path(
     typeface_id =
         c_font_collection->assets->registerTypefaceFromPathWithTracking(
             path_str, typeface);
+  }
+  if (typeface_id) {
+    c_font_collection->markCachesDirty();
   }
   return typeface_id;
 }
@@ -2439,6 +2448,7 @@ bool skiac_font_collection_set_alias(skiac_font_collection* c_font_collection,
   // Register the alias - this will shadow any existing font with the same name
   c_font_collection->assets->registerTypeface(std::move(typeface),
                                               SkString(alias));
+  c_font_collection->markCachesDirty();
   return true;
 }
 

--- a/skia-c/skia_c.hpp
+++ b/skia-c/skia_c.hpp
@@ -543,6 +543,10 @@ struct skiac_font_collection {
   std::vector<sk_sp<TypefaceFontProviderCustom>> retired_assets;
   // Track setAlias mappings for rebuild: {family, alias} pairs
   std::set<std::pair<std::string, std::string>> set_aliases;
+  // Set when the dynamic provider gains a face or an alias. FontCollection
+  // memoizes findTypefaces() per {family list, weight, slant}, including
+  // fallback misses, so any such change can invalidate an existing match.
+  bool caches_dirty = false;
 
   skiac_font_collection()
       : collection(sk_make_sp<FontCollection>()),
@@ -554,6 +558,18 @@ struct skiac_font_collection {
     collection->enableFontFallback();
   }
 
+  // Defer invalidation to the next text lookup instead of clearing on every
+  // registration: loadFontsFromDir() registers one face per file, and
+  // clearCaches() also purges the process-wide HarfBuzz face cache.
+  void markCachesDirty() { caches_dirty = true; }
+
+  void flushCachesIfDirty() {
+    if (caches_dirty) {
+      collection->clearCaches();
+      caches_dirty = false;
+    }
+  }
+
   // Rebuild the dynamic font provider with only remaining fonts
   // Since sk_sp is reference-counted, old providers stay alive as long as any
   // typeface from them is still in use. We can safely clear retired_assets.
@@ -563,6 +579,7 @@ struct skiac_font_collection {
 
     // Clear caches before swap
     collection->clearCaches();
+    caches_dirty = false;
 
     // Create new provider
     auto new_assets = sk_make_sp<TypefaceFontProviderCustom>(font_mgr);


### PR DESCRIPTION
Closes #1329.

## Problem

`skparagraph`'s `FontCollection` memoizes `findTypefaces()` per `{family list, weight, slant}` and stores fallback misses too (`FontCollection.cpp:141-143`, unconditional store at `:181`). Invalidation was asymmetric:

| Path | Cleared the cache? |
|---|---|
| `register` | **No** |
| `registerFromPath` | **No** |
| `setAlias` | **No** |
| `loadFontsFromDir` / `loadSystemFonts` | **No** |
| `remove` / `removeBatch` / `removeAll` | Yes, via `rebuildAssets()` |

So any family or weight resolved before its face was registered stayed pinned to the older match for the rest of the process. The collection is process-global (`src/global_fonts.rs:18`), so a new canvas did not help.

The negative-caching case is the worse one: draw text in a family before registering it, and the key is pinned to the fallback face. This build seeds `SkFontMgr_New_Custom_Empty` with `SkTypeface_Empty`, so that often renders blank or tofu.

## Fix

Deferred invalidation. `register`, `registerFromPath` and `setAlias` set a `caches_dirty` flag. `skiac_canvas_get_line_metrics_or_draw_text` flushes once before the next lookup.

A flush per registration was the other option. It is worse: `loadSystemFonts()` registers one face per file, and `clearCaches()` also purges the **process-wide** HarfBuzz face cache. Deferring keeps a directory load at one clear instead of hundreds.

The flush runs under the existing `Mutex<FontCollection>`, which both text paths already hold (`src/ctx.rs:1721`, `:1825`).

There is no narrower option: `fFaceCache` is private and its type is incomplete in the header, so clearing only the face map would need a Skia patch.

## Tests

`__test__/issue-1329-font-cache.spec.ts`, in its own file because the cache is process-global and AVA sets `workerThreads: false`.

Written first and verified failing against the unmodified binary:

| Test | Before | Expected |
|---|---|---|
| late registration | 287.94 | 308.64 |
| second weight | 354.90 | 308.64 |
| size not in key | 177.45 | 154.32 |
| `setAlias` | 287.94 | 308.64 |
| `registerFromPath` | 287.94 | 308.64 |

All 5 pass after the fix. Full suite: 633 passed, 13 skipped, 1 pre-existing `test.failing` (`__test__/image.spec.ts:776`, unrelated to fonts).

## Note for the reporter

The issue says `remove` is not a usable workaround, because dedupe makes it drop sibling aliases. The dedupe part is right, the conclusion is not. Any successful removal calls `rebuildAssets()`, so a sacrificial font flushes the cache without touching your real fonts:

```js
const tmp = GlobalFonts.register(readFileSync('small-font.ttf'), '__flush__')
GlobalFonts.remove(tmp)
```

That workaround is no longer needed with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YK3fHD535dQv6jEW1sxMjz

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes process-global font resolution and cache flushing on every registration path; impact is mitigated by deferred flush and targeted regression tests, but incorrect invalidation could affect all text rendering.
> 
> **Overview**
> Fixes **#1329**, where skparagraph’s `FontCollection` kept memoized `findTypefaces()` results (including fallback misses) after `GlobalFonts.register`, `registerFromPath`, or `setAlias`, so text could stay on the wrong face for the rest of the process.
> 
> The native layer now sets a **`caches_dirty`** flag when a dynamic face or alias is added, and **`flushCachesIfDirty()`** runs once at the start of the next text draw/measure path to call `FontCollection::clearCaches()`. Invalidation is **deferred** so bulk loads (e.g. `loadFontsFromDir`) don’t trigger a full clear (and HarfBuzz face cache purge) on every file.
> 
> Adds **`__test__/issue-1329-font-cache.spec.ts`** with serial `measureText` checks for late registration, a second weight on the same family, shared cache keys across font sizes, `setAlias`, and `registerFromPath`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eea147999a10cf2b99a91b51a710513b9a7f5c74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->