### PR TITLE
fix(deps): update cssparser to 0.38 and cssparser-color to 0.6

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,6 +9,11 @@
       "groupName": "rust toolchain",
       "matchManagers": ["custom.regex"],
       "matchDepNames": ["rustc"]
+    },
+    {
+      "groupName": "cssparser",
+      "matchManagers": ["cargo"],
+      "matchPackageNames": ["cssparser", "cssparser-color"]
     }
   ],
   "lockFileMaintenance": {

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ crate-type = ["cdylib"]
 [dependencies]
 anyhow          = "1"
 base64-simd     = "0.8"
-cssparser       = "0.37"
-cssparser-color = "0.5"
+cssparser       = "0.38"
+cssparser-color = "0.6"
 gif             = "0.14"
 imagesize       = { version = "0.15", default-features = false, features = ["png", "jpeg", "gif", "webp", "heif"] }
 infer           = "0.22"

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -5,7 +5,7 @@ use std::result;
 use std::str::FromStr;
 use std::sync::LazyLock;
 
-use cssparser::{Parser, ParserInput};
+use cssparser::Parser;
 use cssparser_color::{Color as CSSColor, hsl_to_rgb};
 use libavif::AvifData;
 use napi::{JsString, bindgen_prelude::*};
@@ -1187,8 +1187,7 @@ impl Context {
   }
 
   pub fn set_shadow_color(&mut self, shadow_color: String) -> result::Result<(), SkError> {
-    let mut parser_input = ParserInput::new(&shadow_color);
-    let mut parser = Parser::new(&mut parser_input);
+    let mut parser = Parser::new(&shadow_color);
     let color = CSSColor::parse(&mut parser)
       .map_err(|e| SkError::Generic(format!("Parse color [{}] error: {:?}", shadow_color, e)))?;
 
@@ -1199,7 +1198,7 @@ impl Context {
         ));
       }
       CSSColor::Rgba(rgba) => {
-        drop(parser_input);
+        drop(parser);
         self.state.shadow_color_string = shadow_color;
         // Convert RgbaLegacy to RGBA<u8>
         self.state.shadow_color = RGBA {
@@ -1217,7 +1216,7 @@ impl Context {
 
         let (r, g, b) = hsl_to_rgb(h, s, l);
 
-        drop(parser_input);
+        drop(parser);
         self.state.shadow_color_string = shadow_color;
         self.state.shadow_color = RGBA {
           r: (r * 255.0) as u8,

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,6 +1,6 @@
 use std::num::ParseFloatError;
 
-use cssparser::{Parser, ParserInput};
+use cssparser::Parser;
 use cssparser_color::{Color, RgbaLegacy, hsl_to_rgb};
 use nom::{
   AsChar, Err, IResult, Parser as NomParser,
@@ -217,8 +217,7 @@ fn drop_shadow_parser(input: &str) -> IResult<&str, CssFilter> {
     a: 255,
   };
   let shadow_color = if !shadow_color_str.is_empty() {
-    let mut parser_input = ParserInput::new(shadow_color_str);
-    let mut parser = Parser::new(&mut parser_input);
+    let mut parser = Parser::new(shadow_color_str);
     let color = Color::parse(&mut parser).unwrap_or_else(|_| {
       Color::Rgba(RgbaLegacy {
         red: 0,

--- a/src/gradient.rs
+++ b/src/gradient.rs
@@ -1,6 +1,6 @@
 use std::result;
 
-use cssparser::{Parser, ParserInput};
+use cssparser::Parser;
 use cssparser_color::{Color as CSSColor, hsl_to_rgb};
 use napi::bindgen_prelude::*;
 
@@ -169,8 +169,7 @@ impl CanvasGradient {
       return Ok(());
     }
     let color_str = color.as_str();
-    let mut parser_input = ParserInput::new(color_str);
-    let mut parser = Parser::new(&mut parser_input);
+    let mut parser = Parser::new(color_str);
     let color = CSSColor::parse(&mut parser).map_err(|e| {
       Error::new(
         Status::InvalidArg,

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -1,7 +1,7 @@
 use std::result::Result as StdResult;
 use std::sync::{Arc, OnceLock};
 
-use cssparser::{Parser, ParserInput};
+use cssparser::Parser;
 use cssparser_color::{Color as CSSColor, hsl_to_rgb};
 use napi::bindgen_prelude::*;
 use rgb::RGBA;
@@ -39,8 +39,7 @@ impl Default for Pattern {
 
 impl Pattern {
   pub fn from_color(color_str: &str) -> StdResult<Self, SkError> {
-    let mut parser_input = ParserInput::new(color_str);
-    let mut parser = Parser::new(&mut parser_input);
+    let mut parser = Parser::new(color_str);
     let color = CSSColor::parse(&mut parser)
       .map_err(|e| SkError::Generic(format!("Parse color [{color_str}] error: {e:?}")))?;
     match color {


### PR DESCRIPTION
Closes #1332
Closes #1333

## Why one PR

The API break spans both crates. Neither renovate PR compiles alone.

## Breaking change

`cssparser` 0.38 removed `ParserInput`. `Parser` now carries one lifetime and takes the string directly.

```rust
// before
let mut input = ParserInput::new(s);
let mut parser = Parser::new(&mut input);

// after
let mut parser = Parser::new(s);
```

## Changes

| File | Change |
|---|---|
| `Cargo.toml` | `cssparser` 0.37 → 0.38, `cssparser-color` 0.5 → 0.6 |
| `src/ctx.rs` | import, `Parser::new`, `drop(parser_input)` → `drop(parser)` |
| `src/filter.rs` | import, `Parser::new` |
| `src/gradient.rs` | import, `Parser::new` |
| `src/pattern.rs` | import, `Parser::new` |
| `.github/renovate.json` | new `cssparser` group |

The `drop()` calls in `set_shadow_color` release the borrow on `shadow_color` before the move. That borrow now lives in `parser`.

## Renovate group

```json
{
  "groupName": "cssparser",
  "matchManagers": ["cargo"],
  "matchPackageNames": ["cssparser", "cssparser-color"]
}
```

Renovate opens one PR for both crates from now on.

## Behavior

`cssparser-color` 0.6 changes lifetimes only. The color math is untouched. One visible difference: `ParseError` no longer carries the source location or the offending token, so the `{:?}` text in `Parse color [...] error: {:?}` is shorter. No test asserts on that text.

## Verification

| Check | Result |
|---|---|
| `cargo clippy --all-targets` | clean |
| `yarn build` | exit 0 |
| `yarn test` | 634 passed, 1 known failure, 13 skipped |
| `renovate-config-validator` | valid |

The known failure is the declared `test.failing()` at `__test__/image.spec.ts:776`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BLEt4yyKErDvhUgJmbfm8Q

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical dependency API migration across CSS color parsing only; no auth, data, or rendering logic changes beyond error string formatting.
> 
> **Overview**
> Bumps **cssparser** (0.37 → 0.38) and **cssparser-color** (0.5 → 0.6) together so the crate pair still compiles; Renovate now groups both under a single `cssparser` package rule.
> 
> **cssparser** 0.38 drops `ParserInput`: color parsing now uses `Parser::new(&str)` directly. Call sites in `ctx`, `filter`, `gradient`, and `pattern` drop the `ParserInput` import and wrapper; in `set_shadow_color`, `drop(parser_input)` becomes `drop(parser)` so the string can be moved after parsing.
> 
> Rendering behavior is unchanged aside from slightly shorter color parse error messages (`ParseError` no longer includes location/token detail).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93c783d9d86bf20dfd05d4c8c2830cd546850dfb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->