### PR TITLE
feat: chrome/m154

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -1,7 +1,7 @@
 # `skr canvas`
 
 ![CI](https://github.com/Brooooooklyn/canvas/workflows/CI/badge.svg)
-![Skia Version](https://img.shields.io/badge/Skia-chrome%2Fm151-hotpink)
+![Skia Version](https://img.shields.io/badge/Skia-chrome%2Fm154-hotpink)
 [![install size](https://packagephobia.com/badge?p=@napi-rs/canvas)](https://packagephobia.com/result?p=@napi-rs/canvas)
 [![Downloads](https://img.shields.io/npm/dm/@napi-rs/canvas.svg?sanitize=true)](https://npmcharts.com/compare/@napi-rs/canvas?minimal=true)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `skr canvas`
 
 [![CI](https://github.com/Brooooooklyn/canvas/actions/workflows/CI.yaml/badge.svg)](https://github.com/Brooooooklyn/canvas/actions/workflows/CI.yaml)
-![Skia Version](https://img.shields.io/badge/Skia-chrome%2Fm151-hotpink)
+![Skia Version](https://img.shields.io/badge/Skia-chrome%2Fm154-hotpink)
 [![install size](https://packagephobia.com/badge?p=@napi-rs/canvas)](https://packagephobia.com/result?p=@napi-rs/canvas)
 [![Downloads](https://img.shields.io/npm/dm/@napi-rs/canvas.svg?sanitize=true)](https://npmcharts.com/compare/@napi-rs/canvas?minimal=true)
 

--- a/scripts/build-skia.js
+++ b/scripts/build-skia.js
@@ -46,8 +46,7 @@ const PDF_HARFBUZZ_SUBSET_CRASHING_TARGETS = new Set([
 // binary is x86_64-pc-windows-msvc and is affected by the crash. Match the
 // native host explicitly in addition to the --target= lookup.
 const IS_NATIVE_WIN_X64 = !TARGET_TRIPLE && PLATFORM_NAME === 'win32' && HOST_ARCH === 'x64'
-const PDF_HARFBUZZ_SUBSET_ENABLED =
-  !PDF_HARFBUZZ_SUBSET_CRASHING_TARGETS.has(TARGET_TRIPLE) && !IS_NATIVE_WIN_X64
+const PDF_HARFBUZZ_SUBSET_ENABLED = !PDF_HARFBUZZ_SUBSET_CRASHING_TARGETS.has(TARGET_TRIPLE) && !IS_NATIVE_WIN_X64
 
 function exec(command) {
   console.info(command)
@@ -186,8 +185,16 @@ switch (PLATFORM_NAME) {
 switch (TARGET_TRIPLE) {
   case 'aarch64-unknown-linux-gnu':
     ExtraSkiaBuildFlag += ' target_cpu="arm64" target_os="linux"'
+    // -DAT_HWCAP2=26: the highway roll in Skia m152 taught hwy/targets.cc to probe the
+    // aarch64 CPU through getauxval(AT_HWCAP2). Highway backfills the HWCAP2_* bit values
+    // it reads (targets.cc:502-507) but not the auxv key itself, and glibc only added
+    // AT_HWCAP2 to elf.h in 2.18, so the 2.17 sysroot this target builds against fails
+    // with "use of undeclared identifier 'AT_HWCAP2'". 26 is the fixed Linux uapi value
+    // from linux/auxvec.h, identical to what glibc >= 2.18 defines, so a newer sysroot
+    // would redefine it token-for-token. getauxval returns 0 for a key the kernel does
+    // not supply, which highway reads as "no SVE2", so the probe stays correct.
     ExtraCflags =
-      '"--target=aarch64-unknown-linux-gnu", "--sysroot=/usr/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot", "-I/usr/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot/usr/include", "-march=armv8-a"'
+      '"--target=aarch64-unknown-linux-gnu", "--sysroot=/usr/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot", "-I/usr/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot/usr/include", "-march=armv8-a", "-DAT_HWCAP2=26"'
     ExtraCflagsCC +=
       ', "--target=aarch64-unknown-linux-gnu", "--sysroot=/usr/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot", "-I/usr/lib/llvm-19/include/c++/v1", "-I/usr/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot/usr/include", "-march=armv8-a"'
     ExtraLdFlags =
@@ -314,6 +321,46 @@ if (PLATFORM_NAME === 'win32') {
   writeFileSync(SkLoadICUCppFilePath, patch)
   process.once('beforeExit', () => {
     writeFileSync(SkLoadICUCppFilePath, content)
+  })
+}
+
+// gn/BUILDCONFIG.gn only trusts `cc`/`cxx` named literally clang/clang++; for anything
+// else it shells out to gn/is_clang.py to detect the compiler. Skia commit 7e658a67a1
+// ("Disable partition_alloc on Mac/iOS when using Xcode clang", first shipped in m152)
+// rewrote that probe from
+//   subprocess.check_output('%s --version' % cc, shell=True)
+// to
+//   subprocess.check_output([cc, '--version'])
+// The list form execs argv[0] verbatim, so our musl targets - which build through
+// cc="zig cc" / cxx="zig c++" - make it look for a single binary named `zig cc`, raise
+// FileNotFoundError, and take `gn gen` down with them. Split the multi-word compiler
+// back into argv while we run. This only touches the probe: the toolchain still invokes
+// `zig cc` exactly as before.
+const IsClangPyPath = path.join(__dirname, '..', 'skia', 'gn', 'is_clang.py')
+const IS_CLANG_CODE_TO_PATCH = [
+  `subprocess.check_output([cc, '--version'])`,
+  `subprocess.check_output([cxx, '--version'])`,
+]
+const IS_CLANG_CODE_I_WANT = [
+  `subprocess.check_output(cc.split() + ['--version'])`,
+  `subprocess.check_output(cxx.split() + ['--version'])`,
+]
+
+if (CC.includes(' ') || CXX.includes(' ')) {
+  const isClangContent = readFileSync(IsClangPyPath, 'utf8')
+  let patched = isClangContent
+  IS_CLANG_CODE_TO_PATCH.forEach((codeToPatch, index) => {
+    if (!patched.includes(codeToPatch)) {
+      throw new Error(
+        `skia/gn/is_clang.py does not contain ${JSON.stringify(codeToPatch)} any more. ` +
+          `Re-check the multi-word cc/cxx workaround in scripts/build-skia.js.`,
+      )
+    }
+    patched = patched.replace(codeToPatch, IS_CLANG_CODE_I_WANT[index])
+  })
+  writeFileSync(IsClangPyPath, patched)
+  process.once('beforeExit', () => {
+    writeFileSync(IsClangPyPath, isClangContent)
   })
 }
 

--- a/scripts/build-skia.js
+++ b/scripts/build-skia.js
@@ -332,25 +332,27 @@ if (PLATFORM_NAME === 'win32') {
 // wherever the optimiser does not fold the branch away, and libskia.a ships an undefined
 // hwy::VectorBytes(). macOS bundles tolerate that, but dlopen of the Linux .node fails
 // with "undefined symbol: _ZN3hwy11VectorBytesEv". Compile the missing source.
+// The anchor is a single line because the Windows runners check the submodule out with
+// CRLF endings, which a multi-line needle would never match.
 const HighwayGNPath = path.join(__dirname, '..', 'skia', 'third_party', 'highway', 'BUILD.gn')
-const HIGHWAY_SOURCES_TO_PATCH = `  sources = [
-    "../externals/highway/hwy/aligned_allocator.cc",
-    "../externals/highway/hwy/targets.cc",
-  ]`
-const HIGHWAY_SOURCES_I_WANT = `  sources = [
-    "../externals/highway/hwy/aligned_allocator.cc",
-    "../externals/highway/hwy/per_target.cc",
-    "../externals/highway/hwy/targets.cc",
-  ]`
+const HIGHWAY_SOURCE_TO_PATCH = `"../externals/highway/hwy/targets.cc",`
+const HIGHWAY_SOURCE_ADDED = `"../externals/highway/hwy/per_target.cc",`
 
 const HIGHWAY_GN_CONTENT = readFileSync(HighwayGNPath, 'utf8')
-if (!HIGHWAY_GN_CONTENT.includes(HIGHWAY_SOURCES_TO_PATCH)) {
+if (!HIGHWAY_GN_CONTENT.includes(HIGHWAY_SOURCE_TO_PATCH)) {
   throw new Error(
-    `skia/third_party/highway/BUILD.gn no longer lists the sources this build patches. ` +
+    `skia/third_party/highway/BUILD.gn no longer lists ${HIGHWAY_SOURCE_TO_PATCH}. ` +
       `Re-check whether hwy/per_target.cc is compiled upstream now.`,
   )
 }
-writeFileSync(HighwayGNPath, HIGHWAY_GN_CONTENT.replace(HIGHWAY_SOURCES_TO_PATCH, HIGHWAY_SOURCES_I_WANT))
+const HIGHWAY_GN_EOL = HIGHWAY_GN_CONTENT.includes('\r\n') ? '\r\n' : '\n'
+writeFileSync(
+  HighwayGNPath,
+  HIGHWAY_GN_CONTENT.replace(
+    HIGHWAY_SOURCE_TO_PATCH,
+    `${HIGHWAY_SOURCE_ADDED}${HIGHWAY_GN_EOL}    ${HIGHWAY_SOURCE_TO_PATCH}`,
+  ),
+)
 process.once('beforeExit', () => {
   writeFileSync(HighwayGNPath, HIGHWAY_GN_CONTENT)
 })

--- a/scripts/build-skia.js
+++ b/scripts/build-skia.js
@@ -324,6 +324,37 @@ if (PLATFORM_NAME === 'win32') {
   })
 }
 
+// skia/third_party/highway/BUILD.gn still lists the two sources highway had when the
+// wrapper was written in 2021. The highway roll in Skia m152 made hwy/targets.cc call
+// hwy::VectorBytes() (targets.cc:754) to tell HWY_SVE_256 and HWY_SVE2_128 apart, and
+// that function lives in hwy/per_target.cc, which nothing compiles. The call sits behind
+// a plain `if (HWY_ARCH_ARM_A64)` rather than an #if, so every target keeps the reference
+// wherever the optimiser does not fold the branch away, and libskia.a ships an undefined
+// hwy::VectorBytes(). macOS bundles tolerate that, but dlopen of the Linux .node fails
+// with "undefined symbol: _ZN3hwy11VectorBytesEv". Compile the missing source.
+const HighwayGNPath = path.join(__dirname, '..', 'skia', 'third_party', 'highway', 'BUILD.gn')
+const HIGHWAY_SOURCES_TO_PATCH = `  sources = [
+    "../externals/highway/hwy/aligned_allocator.cc",
+    "../externals/highway/hwy/targets.cc",
+  ]`
+const HIGHWAY_SOURCES_I_WANT = `  sources = [
+    "../externals/highway/hwy/aligned_allocator.cc",
+    "../externals/highway/hwy/per_target.cc",
+    "../externals/highway/hwy/targets.cc",
+  ]`
+
+const HIGHWAY_GN_CONTENT = readFileSync(HighwayGNPath, 'utf8')
+if (!HIGHWAY_GN_CONTENT.includes(HIGHWAY_SOURCES_TO_PATCH)) {
+  throw new Error(
+    `skia/third_party/highway/BUILD.gn no longer lists the sources this build patches. ` +
+      `Re-check whether hwy/per_target.cc is compiled upstream now.`,
+  )
+}
+writeFileSync(HighwayGNPath, HIGHWAY_GN_CONTENT.replace(HIGHWAY_SOURCES_TO_PATCH, HIGHWAY_SOURCES_I_WANT))
+process.once('beforeExit', () => {
+  writeFileSync(HighwayGNPath, HIGHWAY_GN_CONTENT)
+})
+
 // gn/BUILDCONFIG.gn only trusts `cc`/`cxx` named literally clang/clang++; for anything
 // else it shells out to gn/is_clang.py to detect the compiler. Skia commit 7e658a67a1
 // ("Disable partition_alloc on Mac/iOS when using Xcode clang", first shipped in m152)


### PR DESCRIPTION
Upgrade the Skia submodule from `chrome/m151` to `chrome/m154` (`a9c42c9fce`).

Prebuilt binaries: `skia-a9c42c9f`, 111 assets, 11/11 build jobs green.

## Build fixes

Two upstream changes that landed in m152 broke three targets. Both are fixed in `scripts/build-skia.js`.

**`gn gen` aborted on both musl targets.** Skia `7e658a67a1` rewrote `gn/is_clang.py` from
`subprocess.check_output('%s --version' % cc, shell=True)` to `subprocess.check_output([cc, '--version'])`.
`gn/BUILDCONFIG.gn:97-101` runs that probe whenever `cc` is not literally `clang`, and the musl targets build
through `cc="zig cc"`, so the list form looked for one binary named `zig cc` and died with `FileNotFoundError`.
The build now splits a multi-word compiler back into argv for the duration of the run, mirroring the existing
`SkLoadICU.cpp` patch. Only the probe changes; the toolchain still invokes `zig cc` as before.

**`aarch64-unknown-linux-gnu` failed to compile highway.** The highway roll taught `hwy/targets.cc` to read
`getauxval(AT_HWCAP2)`. Highway backfills the `HWCAP2_*` bit values it tests but not the auxv key itself, and
glibc only added `AT_HWCAP2` to `elf.h` in 2.18, so the glibc 2.17 sysroot failed with
`use of undeclared identifier 'AT_HWCAP2'`. It is now defined to 26, the fixed Linux uapi value, for that
target only. `getauxval` returns 0 for a key the kernel does not supply, which highway reads as "no SVE2", so
the probe stays correct.

## Verification

- Local `aarch64-apple-darwin`: skia builds, the addon links, `yarn test` passes with no snapshot changes.
- `gn gen` completes locally for `x86_64-unknown-linux-musl`, and the build reaches 1820/1839 targets.
- `hwy/targets.cc` compiles clean for `aarch64-linux-musl`; `AT_HWCAP2 == 26` asserted against the musl headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EX8YnCn8x3vFKAKGfHUuyu

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large native dependency bump with invasive, fragile build-time patches to vendored Skia GN/Python; failures would block releases for musl and aarch64-gnu, but runtime API surface in the diff is minimal.
> 
> **Overview**
> **Bumps the bundled Skia from `chrome/m151` to `chrome/m154`**, reflected in the README version badges. The substantive work is in `scripts/build-skia.js`, which adds **temporary, revert-on-exit patches** so CI can build the new Skia on several Linux targets.
> 
> For **`aarch64-unknown-linux-gnu`**, compile flags now define **`AT_HWCAP2=26`** so Highway’s `getauxval` probe builds against the older glibc 2.17 sysroot after the m152 Highway roll.
> 
> For **musl builds using `zig cc` / `zig c++`**, **`gn/is_clang.py`** is patched so multi-word compiler strings are split into argv during the clang probe, fixing `gn gen` failures from Skia m152’s list-form `subprocess.check_output`.
> 
> **`third_party/highway/BUILD.gn`** is patched to compile **`hwy/per_target.cc`**, supplying **`hwy::VectorBytes()`** so Linux `.node` loads do not fail on an undefined symbol after the Highway update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b04ecd0628c1cb8c0a75245d87394ad423355ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->